### PR TITLE
Declare dependencies in the gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
-source :rubygems
+source 'https://rubygems.org'
 
-gem 'nokogiri'
-gem 'rest-client'
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,14 @@
-GEM
-  remote: http://rubygems.org/
+PATH
+  remote: .
   specs:
-    mime-types (1.17.2)
+    ierail (0.3)
+      nokogiri
+      rest-client
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    mime-types (1.23)
     nokogiri (1.5.0)
     rest-client (1.6.7)
       mime-types (>= 1.16)
@@ -10,5 +17,4 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  nokogiri
-  rest-client
+  ierail!

--- a/ierail.gemspec
+++ b/ierail.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |s|
   s.authors     = ["Oisin Hurley", "Gary Rafferty"]
   s.email       = 'oi.sin@nis.io'
   s.files       = ["lib/ierail.rb", "lib/station.rb", "lib/station_data.rb","lib/train.rb"]
-  s.homepage    =
-    'http://rubygems.org/gems/ierail'
+  s.homepage    = 'http://rubygems.org/gems/ierail'
+  s.add_dependency 'nokogiri'
+  s.add_dependency 'rest-client'
 end


### PR DESCRIPTION
Was installing this gem recently for something, and noticed we didn't add the deps on nokogiri & rest-client into the gemspec. No biggie, but may as well add them in. 
