### PR TITLE
Update parsing of expected arrival/departure times. Correct test case behaviour.

### DIFF
--- a/fixtures/vcr_cassettes/find_station.yml
+++ b/fixtures/vcr_cassettes/find_station.yml
@@ -25,7 +25,7 @@ http_interactions:
       Server:
       - ''
       Date:
-      - Sat, 19 Apr 2014 18:10:55 GMT
+      - Mon, 05 Oct 2015 20:06:38 GMT
       Content-Length:
       - '428'
     body:
@@ -36,5 +36,5 @@ http_interactions:
         \   <StationDesc>Dublin Connolly</StationDesc>\r\n    <StationCode>CNLLY</StationCode>\r\n
         \ </objStationFilter>\r\n</ArrayOfObjStationFilter>"
     http_version: 
-  recorded_at: Sat, 19 Apr 2014 18:10:57 GMT
-recorded_with: VCR 2.9.0
+  recorded_at: Mon, 05 Oct 2015 20:06:38 GMT
+recorded_with: VCR 2.9.3

--- a/fixtures/vcr_cassettes/northbound.yml
+++ b/fixtures/vcr_cassettes/northbound.yml
@@ -25,217 +25,198 @@ http_interactions:
       Server:
       - ''
       Date:
-      - Sat, 19 Apr 2014 18:10:55 GMT
+      - Mon, 05 Oct 2015 20:06:37 GMT
       Content-Length:
-      - '16433'
+      - '14913'
     body:
       encoding: UTF-8
       string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ArrayOfObjStationData
         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-        xmlns=\"http://api.irishrail.ie/realtime/\">\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.34</Servertime>\r\n
-        \   <Traincode>D819 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Dublin Pearse</Origin>\r\n
-        \   <Destination>Drogheda</Destination>\r\n    <Origintime>19:13</Origintime>\r\n
-        \   <Destinationtime>20:16</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>10</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>19:19</Exparrival>\r\n
-        \   <Expdepart>19:20</Expdepart>\r\n    <Scharrival>19:19</Scharrival>\r\n
-        \   <Schdepart>19:20</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
+        xmlns=\"http://api.irishrail.ie/realtime/\">\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.563</Servertime>\r\n
+        \   <Traincode>E934 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Bray</Origin>\r\n    <Destination>Howth</Destination>\r\n
+        \   <Origintime>20:25</Origintime>\r\n    <Destinationtime>21:33</Destinationtime>\r\n
+        \   <Status>En Route</Status>\r\n    <Lastlocation>Departed Dublin Pearse</Lastlocation>\r\n
+        \   <Duein>5</Duein>\r\n    <Late>2</Late>\r\n    <Exparrival>21:10</Exparrival>\r\n
+        \   <Expdepart>21:11</Expdepart>\r\n    <Scharrival>21:08</Scharrival>\r\n
+        \   <Schdepart>21:09</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
+        \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.563</Servertime>\r\n
+        \   <Traincode>D931 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Dublin Pearse</Origin>\r\n
+        \   <Destination>Maynooth</Destination>\r\n    <Origintime>21:10</Origintime>\r\n
+        \   <Destinationtime>21:56</Destinationtime>\r\n    <Status>No Information</Status>\r\n
+        \   <Lastlocation />\r\n    <Duein>11</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>21:16</Exparrival>\r\n
+        \   <Expdepart>21:17</Expdepart>\r\n    <Scharrival>21:16</Scharrival>\r\n
+        \   <Schdepart>21:17</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
         \   <Traintype>Train</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.34</Servertime>\r\n
-        \   <Traincode>E930 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Greystones</Origin>\r\n
-        \   <Destination>Howth</Destination>\r\n    <Origintime>18:30</Origintime>\r\n
-        \   <Destinationtime>19:52</Destinationtime>\r\n    <Status>En Route</Status>\r\n
-        \   <Lastlocation>Arrived Booterstown</Lastlocation>\r\n    <Duein>17</Duein>\r\n
-        \   <Late>-1</Late>\r\n    <Exparrival>19:26</Exparrival>\r\n    <Expdepart>19:27</Expdepart>\r\n
-        \   <Scharrival>19:27</Scharrival>\r\n    <Schdepart>19:28</Schdepart>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.563</Servertime>\r\n
+        \   <Traincode>E830 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Greystones</Origin>\r\n
+        \   <Destination>Malahide</Destination>\r\n    <Origintime>20:30</Origintime>\r\n
+        \   <Destinationtime>21:50</Destinationtime>\r\n    <Status>En Route</Status>\r\n
+        \   <Lastlocation>Arrived Blackrock</Lastlocation>\r\n    <Duein>19</Duein>\r\n
+        \   <Late>1</Late>\r\n    <Exparrival>21:24</Exparrival>\r\n    <Expdepart>21:25</Expdepart>\r\n
+        \   <Scharrival>21:23</Scharrival>\r\n    <Schdepart>21:24</Schdepart>\r\n
         \   <Direction>Northbound</Direction>\r\n    <Traintype>DART</Traintype>\r\n
         \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
-        \   <Servertime>2014-04-19T19:10:55.34</Servertime>\r\n    <Traincode>E827
+        \   <Servertime>2015-10-05T21:06:38.563</Servertime>\r\n    <Traincode>D821
         </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Bray</Origin>\r\n    <Destination>Malahide</Destination>\r\n
-        \   <Origintime>18:55</Origintime>\r\n    <Destinationtime>20:05</Destinationtime>\r\n
-        \   <Status>En Route</Status>\r\n    <Lastlocation>Arrived Glenageary</Lastlocation>\r\n
-        \   <Duein>30</Duein>\r\n    <Late>1</Late>\r\n    <Exparrival>19:39</Exparrival>\r\n
-        \   <Expdepart>19:40</Expdepart>\r\n    <Scharrival>19:38</Scharrival>\r\n
-        \   <Schdepart>19:39</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
-        \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.34</Servertime>\r\n
-        \   <Traincode>D929 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Dublin Pearse</Origin>\r\n
-        \   <Destination>Maynooth</Destination>\r\n    <Origintime>19:40</Origintime>\r\n
-        \   <Destinationtime>20:26</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>37</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>19:46</Exparrival>\r\n
-        \   <Expdepart>19:47</Expdepart>\r\n    <Scharrival>19:46</Scharrival>\r\n
-        \   <Schdepart>19:47</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Dublin Pearse</Origin>\r\n
+        \   <Destination>Drogheda</Destination>\r\n    <Origintime>21:30</Origintime>\r\n
+        \   <Destinationtime>22:32</Destinationtime>\r\n    <Status>No Information</Status>\r\n
+        \   <Lastlocation />\r\n    <Duein>31</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>21:36</Exparrival>\r\n
+        \   <Expdepart>21:37</Expdepart>\r\n    <Scharrival>21:36</Scharrival>\r\n
+        \   <Schdepart>21:37</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
         \   <Traintype>Train</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.34</Servertime>\r\n
-        \   <Traincode>E931 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Bray</Origin>\r\n    <Destination>Howth</Destination>\r\n
-        \   <Origintime>19:10</Origintime>\r\n    <Destinationtime>20:18</Destinationtime>\r\n
-        \   <Status>No Information</Status>\r\n    <Lastlocation />\r\n    <Duein>44</Duein>\r\n
-        \   <Late>0</Late>\r\n    <Exparrival>19:53</Exparrival>\r\n    <Expdepart>19:54</Expdepart>\r\n
-        \   <Scharrival>19:53</Scharrival>\r\n    <Schdepart>19:54</Schdepart>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.563</Servertime>\r\n
+        \   <Traincode>E935 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Bray</Origin>\r\n    <Destination>Howth</Destination>\r\n
+        \   <Origintime>20:55</Origintime>\r\n    <Destinationtime>22:04</Destinationtime>\r\n
+        \   <Status>En Route</Status>\r\n    <Lastlocation>Departed Killiney</Lastlocation>\r\n
+        \   <Duein>35</Duein>\r\n    <Late>1</Late>\r\n    <Exparrival>21:39</Exparrival>\r\n
+        \   <Expdepart>21:41</Expdepart>\r\n    <Scharrival>21:38</Scharrival>\r\n
+        \   <Schdepart>21:40</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
+        \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.563</Servertime>\r\n
+        \   <Traincode>E831 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Greystones</Origin>\r\n
+        \   <Destination>Malahide</Destination>\r\n    <Origintime>21:00</Origintime>\r\n
+        \   <Destinationtime>22:20</Destinationtime>\r\n    <Status>En Route</Status>\r\n
+        \   <Lastlocation>Departed Greystones</Lastlocation>\r\n    <Duein>49</Duein>\r\n
+        \   <Late>1</Late>\r\n    <Exparrival>21:54</Exparrival>\r\n    <Expdepart>21:55</Expdepart>\r\n
+        \   <Scharrival>21:53</Scharrival>\r\n    <Schdepart>21:54</Schdepart>\r\n
         \   <Direction>Northbound</Direction>\r\n    <Traintype>DART</Traintype>\r\n
         \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
-        \   <Servertime>2014-04-19T19:10:55.34</Servertime>\r\n    <Traincode>E932
+        \   <Servertime>2015-10-05T21:06:38.563</Servertime>\r\n    <Traincode>E936
         </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Bray</Origin>\r\n    <Destination>Howth</Destination>\r\n
-        \   <Origintime>19:25</Origintime>\r\n    <Destinationtime>20:33</Destinationtime>\r\n
-        \   <Status>No Information</Status>\r\n    <Lastlocation />\r\n    <Duein>58</Duein>\r\n
-        \   <Late>0</Late>\r\n    <Exparrival>20:07</Exparrival>\r\n    <Expdepart>20:08</Expdepart>\r\n
-        \   <Scharrival>20:07</Scharrival>\r\n    <Schdepart>20:08</Schdepart>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Bray</Origin>\r\n    <Destination>Howth</Destination>\r\n
+        \   <Origintime>21:25</Origintime>\r\n    <Destinationtime>22:35</Destinationtime>\r\n
+        \   <Status>No Information</Status>\r\n    <Lastlocation />\r\n    <Duein>64</Duein>\r\n
+        \   <Late>0</Late>\r\n    <Exparrival>22:09</Exparrival>\r\n    <Expdepart>22:10</Expdepart>\r\n
+        \   <Scharrival>22:09</Scharrival>\r\n    <Schdepart>22:10</Schdepart>\r\n
         \   <Direction>Northbound</Direction>\r\n    <Traintype>DART</Traintype>\r\n
         \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
-        \   <Servertime>2014-04-19T19:10:55.34</Servertime>\r\n    <Traincode>D930
+        \   <Servertime>2015-10-05T21:06:38.563</Servertime>\r\n    <Traincode>D932
         </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Dublin Pearse</Origin>\r\n
-        \   <Destination>Maynooth</Destination>\r\n    <Origintime>20:08</Origintime>\r\n
-        \   <Destinationtime>20:54</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>64</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>20:13</Exparrival>\r\n
-        \   <Expdepart>20:14</Expdepart>\r\n    <Scharrival>20:13</Scharrival>\r\n
-        \   <Schdepart>20:14</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Dublin Pearse</Origin>\r\n
+        \   <Destination>Maynooth</Destination>\r\n    <Origintime>22:12</Origintime>\r\n
+        \   <Destinationtime>22:58</Destinationtime>\r\n    <Status>No Information</Status>\r\n
+        \   <Lastlocation />\r\n    <Duein>73</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>22:18</Exparrival>\r\n
+        \   <Expdepart>22:19</Expdepart>\r\n    <Scharrival>22:18</Scharrival>\r\n
+        \   <Schdepart>22:19</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
         \   <Traintype>Train</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.34</Servertime>\r\n
-        \   <Traincode>D820 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Dublin Pearse</Origin>\r\n
-        \   <Destination>Drogheda</Destination>\r\n    <Origintime>20:13</Origintime>\r\n
-        \   <Destinationtime>21:15</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>70</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>20:19</Exparrival>\r\n
-        \   <Expdepart>20:20</Expdepart>\r\n    <Scharrival>20:19</Scharrival>\r\n
-        \   <Schdepart>20:20</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
-        \   <Traintype>Train</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.34</Servertime>\r\n
-        \   <Traincode>E828 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Greystones</Origin>\r\n
-        \   <Destination>Malahide</Destination>\r\n    <Origintime>19:30</Origintime>\r\n
-        \   <Destinationtime>20:50</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>74</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>20:23</Exparrival>\r\n
-        \   <Expdepart>20:24</Expdepart>\r\n    <Scharrival>20:23</Scharrival>\r\n
-        \   <Schdepart>20:24</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.563</Servertime>\r\n
+        \   <Traincode>E832 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Greystones</Origin>\r\n
+        \   <Destination>Malahide</Destination>\r\n    <Origintime>21:30</Origintime>\r\n
+        \   <Destinationtime>22:50</Destinationtime>\r\n    <Status>No Information</Status>\r\n
+        \   <Lastlocation />\r\n    <Duein>78</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>22:23</Exparrival>\r\n
+        \   <Expdepart>22:24</Expdepart>\r\n    <Scharrival>22:23</Scharrival>\r\n
+        \   <Schdepart>22:24</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
         \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.34</Servertime>\r\n
-        \   <Traincode>E933 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Bray</Origin>\r\n    <Destination>Howth</Destination>\r\n
-        \   <Origintime>19:55</Origintime>\r\n    <Destinationtime>21:02</Destinationtime>\r\n
-        \   <Status>No Information</Status>\r\n    <Lastlocation />\r\n    <Duein>88</Duein>\r\n
-        \   <Late>0</Late>\r\n    <Exparrival>20:37</Exparrival>\r\n    <Expdepart>20:38</Expdepart>\r\n
-        \   <Scharrival>20:37</Scharrival>\r\n    <Schdepart>20:38</Schdepart>\r\n
-        \   <Direction>Northbound</Direction>\r\n    <Traintype>DART</Traintype>\r\n
-        \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
-        \   <Servertime>2014-04-19T19:10:55.34</Servertime>\r\n    <Traincode>P667
-        </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Maynooth</Origin>\r\n
-        \   <Destination>Dublin Pearse</Destination>\r\n    <Origintime>18:40</Origintime>\r\n
-        \   <Destinationtime>19:23</Destinationtime>\r\n    <Status>En Route</Status>\r\n
-        \   <Lastlocation>Departed Ashtown</Lastlocation>\r\n    <Duein>12</Duein>\r\n
-        \   <Late>3</Late>\r\n    <Exparrival>19:22</Exparrival>\r\n    <Expdepart>19:22</Expdepart>\r\n
-        \   <Scharrival>19:18</Scharrival>\r\n    <Schdepart>19:19</Schdepart>\r\n
-        \   <Direction>Southbound</Direction>\r\n    <Traintype>Train</Traintype>\r\n
-        \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
-        \   <Servertime>2014-04-19T19:10:55.34</Servertime>\r\n    <Traincode>E126
-        </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Howth</Origin>\r\n    <Destination>Greystones</Destination>\r\n
-        \   <Origintime>19:00</Origintime>\r\n    <Destinationtime>20:20</Destinationtime>\r\n
-        \   <Status>En Route</Status>\r\n    <Lastlocation>Departed Howth Junction</Lastlocation>\r\n
-        \   <Duein>15</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>19:24</Exparrival>\r\n
-        \   <Expdepart>19:25</Expdepart>\r\n    <Scharrival>19:24</Scharrival>\r\n
-        \   <Schdepart>19:25</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
-        \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.34</Servertime>\r\n
-        \   <Traincode>E227 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Malahide</Origin>\r\n
-        \   <Destination>Bray</Destination>\r\n    <Origintime>19:15</Origintime>\r\n
-        \   <Destinationtime>20:24</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>30</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>19:39</Exparrival>\r\n
-        \   <Expdepart>19:40</Expdepart>\r\n    <Scharrival>19:39</Scharrival>\r\n
-        \   <Schdepart>19:40</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
-        \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.34</Servertime>\r\n
-        \   <Traincode>P622 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Drogheda</Origin>\r\n
-        \   <Destination>Dublin Pearse</Destination>\r\n    <Origintime>18:50</Origintime>\r\n
-        \   <Destinationtime>19:51</Destinationtime>\r\n    <Status>En Route</Status>\r\n
-        \   <Lastlocation>Departed Balbriggan</Lastlocation>\r\n    <Duein>37</Duein>\r\n
-        \   <Late>1</Late>\r\n    <Exparrival>19:46</Exparrival>\r\n    <Expdepart>19:47</Expdepart>\r\n
-        \   <Scharrival>19:45</Scharrival>\r\n    <Schdepart>19:46</Schdepart>\r\n
-        \   <Direction>Southbound</Direction>\r\n    <Traintype>Train</Traintype>\r\n
-        \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
-        \   <Servertime>2014-04-19T19:10:55.34</Servertime>\r\n    <Traincode>E252
-        </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Howth</Origin>\r\n    <Destination>Bray</Destination>\r\n
-        \   <Origintime>19:30</Origintime>\r\n    <Destinationtime>20:39</Destinationtime>\r\n
-        \   <Status>No Information</Status>\r\n    <Lastlocation />\r\n    <Duein>45</Duein>\r\n
-        \   <Late>0</Late>\r\n    <Exparrival>19:54</Exparrival>\r\n    <Expdepart>19:55</Expdepart>\r\n
-        \   <Scharrival>19:54</Scharrival>\r\n    <Schdepart>19:55</Schdepart>\r\n
-        \   <Direction>Southbound</Direction>\r\n    <Traintype>DART</Traintype>\r\n
-        \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
-        \   <Servertime>2014-04-19T19:10:55.34</Servertime>\r\n    <Traincode>E228
-        </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Malahide</Origin>\r\n
-        \   <Destination>Bray</Destination>\r\n    <Origintime>19:45</Origintime>\r\n
-        \   <Destinationtime>20:54</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>60</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>20:09</Exparrival>\r\n
-        \   <Expdepart>20:10</Expdepart>\r\n    <Scharrival>20:09</Scharrival>\r\n
-        \   <Schdepart>20:10</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
-        \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.34</Servertime>\r\n
-        \   <Traincode>A133 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Belfast Central</Origin>\r\n
-        \   <Destination>Dublin Connolly</Destination>\r\n    <Origintime>18:05</Origintime>\r\n
-        \   <Destinationtime>20:15</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>65</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>20:15</Exparrival>\r\n
-        \   <Expdepart>00:00</Expdepart>\r\n    <Scharrival>20:15</Scharrival>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.563</Servertime>\r\n
+        \   <Traincode>A913 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Sligo</Origin>\r\n    <Destination>Dublin
+        Connolly</Destination>\r\n    <Origintime>18:00</Origintime>\r\n    <Destinationtime>21:08</Destinationtime>\r\n
+        \   <Status>En Route</Status>\r\n    <Lastlocation>Arrived Drumcondra</Lastlocation>\r\n
+        \   <Duein>6</Duein>\r\n    <Late>4</Late>\r\n    <Exparrival>21:12</Exparrival>\r\n
+        \   <Expdepart>00:00</Expdepart>\r\n    <Scharrival>21:08</Scharrival>\r\n
         \   <Schdepart>00:00</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
         \   <Traintype>Train</Traintype>\r\n    <Locationtype>D</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.34</Servertime>\r\n
-        \   <Traincode>P668 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Maynooth</Origin>\r\n
-        \   <Destination>Dublin Pearse</Destination>\r\n    <Origintime>19:41</Origintime>\r\n
-        \   <Destinationtime>20:26</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>71</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>20:20</Exparrival>\r\n
-        \   <Expdepart>20:21</Expdepart>\r\n    <Scharrival>20:20</Scharrival>\r\n
-        \   <Schdepart>20:21</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
-        \   <Traintype>Train</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.34</Servertime>\r\n
-        \   <Traincode>E128 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Howth</Origin>\r\n    <Destination>Greystones</Destination>\r\n
-        \   <Origintime>20:00</Origintime>\r\n    <Destinationtime>21:20</Destinationtime>\r\n
-        \   <Status>No Information</Status>\r\n    <Lastlocation />\r\n    <Duein>75</Duein>\r\n
-        \   <Late>0</Late>\r\n    <Exparrival>20:24</Exparrival>\r\n    <Expdepart>20:25</Expdepart>\r\n
-        \   <Scharrival>20:24</Scharrival>\r\n    <Schdepart>20:25</Schdepart>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.563</Servertime>\r\n
+        \   <Traincode>E230 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Howth</Origin>\r\n    <Destination>Bray</Destination>\r\n
+        \   <Origintime>20:45</Origintime>\r\n    <Destinationtime>21:57</Destinationtime>\r\n
+        \   <Status>En Route</Status>\r\n    <Lastlocation>Departed Killester</Lastlocation>\r\n
+        \   <Duein>9</Duein>\r\n    <Late>2</Late>\r\n    <Exparrival>21:14</Exparrival>\r\n
+        \   <Expdepart>21:15</Expdepart>\r\n    <Scharrival>21:12</Scharrival>\r\n
+        \   <Schdepart>21:13</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
+        \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.563</Servertime>\r\n
+        \   <Traincode>E130 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Malahide</Origin>\r\n
+        \   <Destination>Greystones</Destination>\r\n    <Origintime>21:00</Origintime>\r\n
+        \   <Destinationtime>22:20</Destinationtime>\r\n    <Status>En Route</Status>\r\n
+        \   <Lastlocation>Departed Portmarnock</Lastlocation>\r\n    <Duein>20</Duein>\r\n
+        \   <Late>1</Late>\r\n    <Exparrival>21:25</Exparrival>\r\n    <Expdepart>21:26</Expdepart>\r\n
+        \   <Scharrival>21:24</Scharrival>\r\n    <Schdepart>21:25</Schdepart>\r\n
         \   <Direction>Southbound</Direction>\r\n    <Traintype>DART</Traintype>\r\n
         \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
-        \   <Servertime>2014-04-19T19:10:55.34</Servertime>\r\n    <Traincode>E229
+        \   <Servertime>2015-10-05T21:06:38.563</Servertime>\r\n    <Traincode>P670
         </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Malahide</Origin>\r\n
-        \   <Destination>Bray</Destination>\r\n    <Origintime>20:15</Origintime>\r\n
-        \   <Destinationtime>21:24</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>90</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>20:39</Exparrival>\r\n
-        \   <Expdepart>20:40</Expdepart>\r\n    <Scharrival>20:39</Scharrival>\r\n
-        \   <Schdepart>20:40</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Maynooth</Origin>\r\n
+        \   <Destination>Dublin Pearse</Destination>\r\n    <Origintime>20:47</Origintime>\r\n
+        \   <Destinationtime>21:34</Destinationtime>\r\n    <Status>En Route</Status>\r\n
+        \   <Lastlocation>Arrived Clonsilla</Lastlocation>\r\n    <Duein>28</Duein>\r\n
+        \   <Late>5</Late>\r\n    <Exparrival>21:33</Exparrival>\r\n    <Expdepart>21:34</Expdepart>\r\n
+        \   <Scharrival>21:28</Scharrival>\r\n    <Schdepart>21:29</Schdepart>\r\n
+        \   <Direction>Southbound</Direction>\r\n    <Traintype>Train</Traintype>\r\n
+        \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
+        \   <Servertime>2015-10-05T21:06:38.563</Servertime>\r\n    <Traincode>E231
+        </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Howth</Origin>\r\n    <Destination>Bray</Destination>\r\n
+        \   <Origintime>21:15</Origintime>\r\n    <Destinationtime>22:24</Destinationtime>\r\n
+        \   <Status>No Information</Status>\r\n    <Lastlocation />\r\n    <Duein>34</Duein>\r\n
+        \   <Late>0</Late>\r\n    <Exparrival>21:39</Exparrival>\r\n    <Expdepart>21:40</Expdepart>\r\n
+        \   <Scharrival>21:39</Scharrival>\r\n    <Schdepart>21:40</Schdepart>\r\n
+        \   <Direction>Southbound</Direction>\r\n    <Traintype>DART</Traintype>\r\n
+        \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
+        \   <Servertime>2015-10-05T21:06:38.563</Servertime>\r\n    <Traincode>P671
+        </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Maynooth</Origin>\r\n
+        \   <Destination>Dublin Pearse</Destination>\r\n    <Origintime>21:05</Origintime>\r\n
+        \   <Destinationtime>21:49</Destinationtime>\r\n    <Status>No Information</Status>\r\n
+        \   <Lastlocation />\r\n    <Duein>38</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>21:43</Exparrival>\r\n
+        \   <Expdepart>21:44</Expdepart>\r\n    <Scharrival>21:43</Scharrival>\r\n
+        \   <Schdepart>21:44</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
+        \   <Traintype>Train</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.563</Servertime>\r\n
+        \   <Traincode>E131 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Malahide</Origin>\r\n
+        \   <Destination>Greystones</Destination>\r\n    <Origintime>21:30</Origintime>\r\n
+        \   <Destinationtime>22:50</Destinationtime>\r\n    <Status>No Information</Status>\r\n
+        \   <Lastlocation />\r\n    <Duein>49</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>21:54</Exparrival>\r\n
+        \   <Expdepart>21:55</Expdepart>\r\n    <Scharrival>21:54</Scharrival>\r\n
+        \   <Schdepart>21:55</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
         \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.563</Servertime>\r\n
+        \   <Traincode>E232 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Howth</Origin>\r\n    <Destination>Bray</Destination>\r\n
+        \   <Origintime>21:45</Origintime>\r\n    <Destinationtime>22:54</Destinationtime>\r\n
+        \   <Status>No Information</Status>\r\n    <Lastlocation />\r\n    <Duein>64</Duein>\r\n
+        \   <Late>0</Late>\r\n    <Exparrival>22:09</Exparrival>\r\n    <Expdepart>22:10</Expdepart>\r\n
+        \   <Scharrival>22:09</Scharrival>\r\n    <Schdepart>22:10</Schdepart>\r\n
+        \   <Direction>Southbound</Direction>\r\n    <Traintype>DART</Traintype>\r\n
+        \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
+        \   <Servertime>2015-10-05T21:06:38.563</Servertime>\r\n    <Traincode>E710
+        </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Malahide</Origin>\r\n
+        \   <Destination>Dublin Connolly</Destination>\r\n    <Origintime>22:10</Origintime>\r\n
+        \   <Destinationtime>22:35</Destinationtime>\r\n    <Status>No Information</Status>\r\n
+        \   <Lastlocation />\r\n    <Duein>89</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>22:35</Exparrival>\r\n
+        \   <Expdepart>00:00</Expdepart>\r\n    <Scharrival>22:35</Scharrival>\r\n
+        \   <Schdepart>00:00</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
+        \   <Traintype>DART</Traintype>\r\n    <Locationtype>D</Locationtype>\r\n
         \ </objStationData>\r\n</ArrayOfObjStationData>"
     http_version: 
-  recorded_at: Sat, 19 Apr 2014 18:10:57 GMT
-recorded_with: VCR 2.9.0
+  recorded_at: Mon, 05 Oct 2015 20:06:37 GMT
+recorded_with: VCR 2.9.3

--- a/fixtures/vcr_cassettes/southbound.yml
+++ b/fixtures/vcr_cassettes/southbound.yml
@@ -25,217 +25,198 @@ http_interactions:
       Server:
       - ''
       Date:
-      - Sat, 19 Apr 2014 18:10:55 GMT
+      - Mon, 05 Oct 2015 20:06:36 GMT
       Content-Length:
-      - '16433'
+      - '14895'
     body:
       encoding: UTF-8
       string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ArrayOfObjStationData
         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-        xmlns=\"http://api.irishrail.ie/realtime/\">\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.46</Servertime>\r\n
-        \   <Traincode>D819 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Dublin Pearse</Origin>\r\n
-        \   <Destination>Drogheda</Destination>\r\n    <Origintime>19:13</Origintime>\r\n
-        \   <Destinationtime>20:16</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>10</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>19:19</Exparrival>\r\n
-        \   <Expdepart>19:20</Expdepart>\r\n    <Scharrival>19:19</Scharrival>\r\n
-        \   <Schdepart>19:20</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
+        xmlns=\"http://api.irishrail.ie/realtime/\">\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.21</Servertime>\r\n
+        \   <Traincode>E934 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Bray</Origin>\r\n    <Destination>Howth</Destination>\r\n
+        \   <Origintime>20:25</Origintime>\r\n    <Destinationtime>21:33</Destinationtime>\r\n
+        \   <Status>En Route</Status>\r\n    <Lastlocation>Departed Dublin Pearse</Lastlocation>\r\n
+        \   <Duein>5</Duein>\r\n    <Late>2</Late>\r\n    <Exparrival>21:10</Exparrival>\r\n
+        \   <Expdepart>21:11</Expdepart>\r\n    <Scharrival>21:08</Scharrival>\r\n
+        \   <Schdepart>21:09</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
+        \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.21</Servertime>\r\n
+        \   <Traincode>D931 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Dublin Pearse</Origin>\r\n
+        \   <Destination>Maynooth</Destination>\r\n    <Origintime>21:10</Origintime>\r\n
+        \   <Destinationtime>21:56</Destinationtime>\r\n    <Status>No Information</Status>\r\n
+        \   <Lastlocation />\r\n    <Duein>11</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>21:16</Exparrival>\r\n
+        \   <Expdepart>21:17</Expdepart>\r\n    <Scharrival>21:16</Scharrival>\r\n
+        \   <Schdepart>21:17</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
         \   <Traintype>Train</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.46</Servertime>\r\n
-        \   <Traincode>E930 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Greystones</Origin>\r\n
-        \   <Destination>Howth</Destination>\r\n    <Origintime>18:30</Origintime>\r\n
-        \   <Destinationtime>19:52</Destinationtime>\r\n    <Status>En Route</Status>\r\n
-        \   <Lastlocation>Arrived Booterstown</Lastlocation>\r\n    <Duein>17</Duein>\r\n
-        \   <Late>-1</Late>\r\n    <Exparrival>19:26</Exparrival>\r\n    <Expdepart>19:27</Expdepart>\r\n
-        \   <Scharrival>19:27</Scharrival>\r\n    <Schdepart>19:28</Schdepart>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.21</Servertime>\r\n
+        \   <Traincode>E830 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Greystones</Origin>\r\n
+        \   <Destination>Malahide</Destination>\r\n    <Origintime>20:30</Origintime>\r\n
+        \   <Destinationtime>21:50</Destinationtime>\r\n    <Status>En Route</Status>\r\n
+        \   <Lastlocation>Arrived Blackrock</Lastlocation>\r\n    <Duein>19</Duein>\r\n
+        \   <Late>1</Late>\r\n    <Exparrival>21:24</Exparrival>\r\n    <Expdepart>21:25</Expdepart>\r\n
+        \   <Scharrival>21:23</Scharrival>\r\n    <Schdepart>21:24</Schdepart>\r\n
         \   <Direction>Northbound</Direction>\r\n    <Traintype>DART</Traintype>\r\n
         \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
-        \   <Servertime>2014-04-19T19:10:55.46</Servertime>\r\n    <Traincode>E827
+        \   <Servertime>2015-10-05T21:06:38.21</Servertime>\r\n    <Traincode>D821
         </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Bray</Origin>\r\n    <Destination>Malahide</Destination>\r\n
-        \   <Origintime>18:55</Origintime>\r\n    <Destinationtime>20:05</Destinationtime>\r\n
-        \   <Status>En Route</Status>\r\n    <Lastlocation>Arrived Glenageary</Lastlocation>\r\n
-        \   <Duein>30</Duein>\r\n    <Late>1</Late>\r\n    <Exparrival>19:39</Exparrival>\r\n
-        \   <Expdepart>19:40</Expdepart>\r\n    <Scharrival>19:38</Scharrival>\r\n
-        \   <Schdepart>19:39</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
-        \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.46</Servertime>\r\n
-        \   <Traincode>D929 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Dublin Pearse</Origin>\r\n
-        \   <Destination>Maynooth</Destination>\r\n    <Origintime>19:40</Origintime>\r\n
-        \   <Destinationtime>20:26</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>37</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>19:46</Exparrival>\r\n
-        \   <Expdepart>19:47</Expdepart>\r\n    <Scharrival>19:46</Scharrival>\r\n
-        \   <Schdepart>19:47</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Dublin Pearse</Origin>\r\n
+        \   <Destination>Drogheda</Destination>\r\n    <Origintime>21:30</Origintime>\r\n
+        \   <Destinationtime>22:32</Destinationtime>\r\n    <Status>No Information</Status>\r\n
+        \   <Lastlocation />\r\n    <Duein>31</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>21:36</Exparrival>\r\n
+        \   <Expdepart>21:37</Expdepart>\r\n    <Scharrival>21:36</Scharrival>\r\n
+        \   <Schdepart>21:37</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
         \   <Traintype>Train</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.46</Servertime>\r\n
-        \   <Traincode>E931 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Bray</Origin>\r\n    <Destination>Howth</Destination>\r\n
-        \   <Origintime>19:10</Origintime>\r\n    <Destinationtime>20:18</Destinationtime>\r\n
-        \   <Status>No Information</Status>\r\n    <Lastlocation />\r\n    <Duein>44</Duein>\r\n
-        \   <Late>0</Late>\r\n    <Exparrival>19:53</Exparrival>\r\n    <Expdepart>19:54</Expdepart>\r\n
-        \   <Scharrival>19:53</Scharrival>\r\n    <Schdepart>19:54</Schdepart>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.21</Servertime>\r\n
+        \   <Traincode>E935 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Bray</Origin>\r\n    <Destination>Howth</Destination>\r\n
+        \   <Origintime>20:55</Origintime>\r\n    <Destinationtime>22:04</Destinationtime>\r\n
+        \   <Status>En Route</Status>\r\n    <Lastlocation>Departed Killiney</Lastlocation>\r\n
+        \   <Duein>35</Duein>\r\n    <Late>1</Late>\r\n    <Exparrival>21:39</Exparrival>\r\n
+        \   <Expdepart>21:41</Expdepart>\r\n    <Scharrival>21:38</Scharrival>\r\n
+        \   <Schdepart>21:40</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
+        \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.21</Servertime>\r\n
+        \   <Traincode>E831 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Greystones</Origin>\r\n
+        \   <Destination>Malahide</Destination>\r\n    <Origintime>21:00</Origintime>\r\n
+        \   <Destinationtime>22:20</Destinationtime>\r\n    <Status>En Route</Status>\r\n
+        \   <Lastlocation>Departed Greystones</Lastlocation>\r\n    <Duein>49</Duein>\r\n
+        \   <Late>1</Late>\r\n    <Exparrival>21:54</Exparrival>\r\n    <Expdepart>21:55</Expdepart>\r\n
+        \   <Scharrival>21:53</Scharrival>\r\n    <Schdepart>21:54</Schdepart>\r\n
         \   <Direction>Northbound</Direction>\r\n    <Traintype>DART</Traintype>\r\n
         \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
-        \   <Servertime>2014-04-19T19:10:55.46</Servertime>\r\n    <Traincode>E932
+        \   <Servertime>2015-10-05T21:06:38.21</Servertime>\r\n    <Traincode>E936
         </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Bray</Origin>\r\n    <Destination>Howth</Destination>\r\n
-        \   <Origintime>19:25</Origintime>\r\n    <Destinationtime>20:33</Destinationtime>\r\n
-        \   <Status>No Information</Status>\r\n    <Lastlocation />\r\n    <Duein>58</Duein>\r\n
-        \   <Late>0</Late>\r\n    <Exparrival>20:07</Exparrival>\r\n    <Expdepart>20:08</Expdepart>\r\n
-        \   <Scharrival>20:07</Scharrival>\r\n    <Schdepart>20:08</Schdepart>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Bray</Origin>\r\n    <Destination>Howth</Destination>\r\n
+        \   <Origintime>21:25</Origintime>\r\n    <Destinationtime>22:35</Destinationtime>\r\n
+        \   <Status>No Information</Status>\r\n    <Lastlocation />\r\n    <Duein>64</Duein>\r\n
+        \   <Late>0</Late>\r\n    <Exparrival>22:09</Exparrival>\r\n    <Expdepart>22:10</Expdepart>\r\n
+        \   <Scharrival>22:09</Scharrival>\r\n    <Schdepart>22:10</Schdepart>\r\n
         \   <Direction>Northbound</Direction>\r\n    <Traintype>DART</Traintype>\r\n
         \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
-        \   <Servertime>2014-04-19T19:10:55.46</Servertime>\r\n    <Traincode>D930
+        \   <Servertime>2015-10-05T21:06:38.21</Servertime>\r\n    <Traincode>D932
         </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Dublin Pearse</Origin>\r\n
-        \   <Destination>Maynooth</Destination>\r\n    <Origintime>20:08</Origintime>\r\n
-        \   <Destinationtime>20:54</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>64</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>20:13</Exparrival>\r\n
-        \   <Expdepart>20:14</Expdepart>\r\n    <Scharrival>20:13</Scharrival>\r\n
-        \   <Schdepart>20:14</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Dublin Pearse</Origin>\r\n
+        \   <Destination>Maynooth</Destination>\r\n    <Origintime>22:12</Origintime>\r\n
+        \   <Destinationtime>22:58</Destinationtime>\r\n    <Status>No Information</Status>\r\n
+        \   <Lastlocation />\r\n    <Duein>73</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>22:18</Exparrival>\r\n
+        \   <Expdepart>22:19</Expdepart>\r\n    <Scharrival>22:18</Scharrival>\r\n
+        \   <Schdepart>22:19</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
         \   <Traintype>Train</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.46</Servertime>\r\n
-        \   <Traincode>D820 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Dublin Pearse</Origin>\r\n
-        \   <Destination>Drogheda</Destination>\r\n    <Origintime>20:13</Origintime>\r\n
-        \   <Destinationtime>21:15</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>70</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>20:19</Exparrival>\r\n
-        \   <Expdepart>20:20</Expdepart>\r\n    <Scharrival>20:19</Scharrival>\r\n
-        \   <Schdepart>20:20</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
-        \   <Traintype>Train</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.46</Servertime>\r\n
-        \   <Traincode>E828 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Greystones</Origin>\r\n
-        \   <Destination>Malahide</Destination>\r\n    <Origintime>19:30</Origintime>\r\n
-        \   <Destinationtime>20:50</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>74</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>20:23</Exparrival>\r\n
-        \   <Expdepart>20:24</Expdepart>\r\n    <Scharrival>20:23</Scharrival>\r\n
-        \   <Schdepart>20:24</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.21</Servertime>\r\n
+        \   <Traincode>E832 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Greystones</Origin>\r\n
+        \   <Destination>Malahide</Destination>\r\n    <Origintime>21:30</Origintime>\r\n
+        \   <Destinationtime>22:50</Destinationtime>\r\n    <Status>No Information</Status>\r\n
+        \   <Lastlocation />\r\n    <Duein>78</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>22:23</Exparrival>\r\n
+        \   <Expdepart>22:24</Expdepart>\r\n    <Scharrival>22:23</Scharrival>\r\n
+        \   <Schdepart>22:24</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
         \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.46</Servertime>\r\n
-        \   <Traincode>E933 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Bray</Origin>\r\n    <Destination>Howth</Destination>\r\n
-        \   <Origintime>19:55</Origintime>\r\n    <Destinationtime>21:02</Destinationtime>\r\n
-        \   <Status>No Information</Status>\r\n    <Lastlocation />\r\n    <Duein>88</Duein>\r\n
-        \   <Late>0</Late>\r\n    <Exparrival>20:37</Exparrival>\r\n    <Expdepart>20:38</Expdepart>\r\n
-        \   <Scharrival>20:37</Scharrival>\r\n    <Schdepart>20:38</Schdepart>\r\n
-        \   <Direction>Northbound</Direction>\r\n    <Traintype>DART</Traintype>\r\n
-        \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
-        \   <Servertime>2014-04-19T19:10:55.46</Servertime>\r\n    <Traincode>P667
-        </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Maynooth</Origin>\r\n
-        \   <Destination>Dublin Pearse</Destination>\r\n    <Origintime>18:40</Origintime>\r\n
-        \   <Destinationtime>19:23</Destinationtime>\r\n    <Status>En Route</Status>\r\n
-        \   <Lastlocation>Departed Ashtown</Lastlocation>\r\n    <Duein>12</Duein>\r\n
-        \   <Late>3</Late>\r\n    <Exparrival>19:22</Exparrival>\r\n    <Expdepart>19:22</Expdepart>\r\n
-        \   <Scharrival>19:18</Scharrival>\r\n    <Schdepart>19:19</Schdepart>\r\n
-        \   <Direction>Southbound</Direction>\r\n    <Traintype>Train</Traintype>\r\n
-        \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
-        \   <Servertime>2014-04-19T19:10:55.46</Servertime>\r\n    <Traincode>E126
-        </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Howth</Origin>\r\n    <Destination>Greystones</Destination>\r\n
-        \   <Origintime>19:00</Origintime>\r\n    <Destinationtime>20:20</Destinationtime>\r\n
-        \   <Status>En Route</Status>\r\n    <Lastlocation>Departed Howth Junction</Lastlocation>\r\n
-        \   <Duein>15</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>19:24</Exparrival>\r\n
-        \   <Expdepart>19:25</Expdepart>\r\n    <Scharrival>19:24</Scharrival>\r\n
-        \   <Schdepart>19:25</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
-        \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.46</Servertime>\r\n
-        \   <Traincode>E227 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Malahide</Origin>\r\n
-        \   <Destination>Bray</Destination>\r\n    <Origintime>19:15</Origintime>\r\n
-        \   <Destinationtime>20:24</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>30</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>19:39</Exparrival>\r\n
-        \   <Expdepart>19:40</Expdepart>\r\n    <Scharrival>19:39</Scharrival>\r\n
-        \   <Schdepart>19:40</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
-        \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.46</Servertime>\r\n
-        \   <Traincode>P622 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Drogheda</Origin>\r\n
-        \   <Destination>Dublin Pearse</Destination>\r\n    <Origintime>18:50</Origintime>\r\n
-        \   <Destinationtime>19:51</Destinationtime>\r\n    <Status>En Route</Status>\r\n
-        \   <Lastlocation>Departed Balbriggan</Lastlocation>\r\n    <Duein>37</Duein>\r\n
-        \   <Late>1</Late>\r\n    <Exparrival>19:46</Exparrival>\r\n    <Expdepart>19:47</Expdepart>\r\n
-        \   <Scharrival>19:45</Scharrival>\r\n    <Schdepart>19:46</Schdepart>\r\n
-        \   <Direction>Southbound</Direction>\r\n    <Traintype>Train</Traintype>\r\n
-        \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
-        \   <Servertime>2014-04-19T19:10:55.46</Servertime>\r\n    <Traincode>E252
-        </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Howth</Origin>\r\n    <Destination>Bray</Destination>\r\n
-        \   <Origintime>19:30</Origintime>\r\n    <Destinationtime>20:39</Destinationtime>\r\n
-        \   <Status>No Information</Status>\r\n    <Lastlocation />\r\n    <Duein>45</Duein>\r\n
-        \   <Late>0</Late>\r\n    <Exparrival>19:54</Exparrival>\r\n    <Expdepart>19:55</Expdepart>\r\n
-        \   <Scharrival>19:54</Scharrival>\r\n    <Schdepart>19:55</Schdepart>\r\n
-        \   <Direction>Southbound</Direction>\r\n    <Traintype>DART</Traintype>\r\n
-        \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
-        \   <Servertime>2014-04-19T19:10:55.46</Servertime>\r\n    <Traincode>E228
-        </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Malahide</Origin>\r\n
-        \   <Destination>Bray</Destination>\r\n    <Origintime>19:45</Origintime>\r\n
-        \   <Destinationtime>20:54</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>60</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>20:09</Exparrival>\r\n
-        \   <Expdepart>20:10</Expdepart>\r\n    <Scharrival>20:09</Scharrival>\r\n
-        \   <Schdepart>20:10</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
-        \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.46</Servertime>\r\n
-        \   <Traincode>A133 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Belfast Central</Origin>\r\n
-        \   <Destination>Dublin Connolly</Destination>\r\n    <Origintime>18:05</Origintime>\r\n
-        \   <Destinationtime>20:15</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>65</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>20:15</Exparrival>\r\n
-        \   <Expdepart>00:00</Expdepart>\r\n    <Scharrival>20:15</Scharrival>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.21</Servertime>\r\n
+        \   <Traincode>A913 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Sligo</Origin>\r\n    <Destination>Dublin
+        Connolly</Destination>\r\n    <Origintime>18:00</Origintime>\r\n    <Destinationtime>21:08</Destinationtime>\r\n
+        \   <Status>En Route</Status>\r\n    <Lastlocation>Arrived Drumcondra</Lastlocation>\r\n
+        \   <Duein>6</Duein>\r\n    <Late>4</Late>\r\n    <Exparrival>21:12</Exparrival>\r\n
+        \   <Expdepart>00:00</Expdepart>\r\n    <Scharrival>21:08</Scharrival>\r\n
         \   <Schdepart>00:00</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
         \   <Traintype>Train</Traintype>\r\n    <Locationtype>D</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.46</Servertime>\r\n
-        \   <Traincode>P668 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Maynooth</Origin>\r\n
-        \   <Destination>Dublin Pearse</Destination>\r\n    <Origintime>19:41</Origintime>\r\n
-        \   <Destinationtime>20:26</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>71</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>20:20</Exparrival>\r\n
-        \   <Expdepart>20:21</Expdepart>\r\n    <Scharrival>20:20</Scharrival>\r\n
-        \   <Schdepart>20:21</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
-        \   <Traintype>Train</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.46</Servertime>\r\n
-        \   <Traincode>E128 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Howth</Origin>\r\n    <Destination>Greystones</Destination>\r\n
-        \   <Origintime>20:00</Origintime>\r\n    <Destinationtime>21:20</Destinationtime>\r\n
-        \   <Status>No Information</Status>\r\n    <Lastlocation />\r\n    <Duein>75</Duein>\r\n
-        \   <Late>0</Late>\r\n    <Exparrival>20:24</Exparrival>\r\n    <Expdepart>20:25</Expdepart>\r\n
-        \   <Scharrival>20:24</Scharrival>\r\n    <Schdepart>20:25</Schdepart>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.21</Servertime>\r\n
+        \   <Traincode>E230 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Howth</Origin>\r\n    <Destination>Bray</Destination>\r\n
+        \   <Origintime>20:45</Origintime>\r\n    <Destinationtime>21:57</Destinationtime>\r\n
+        \   <Status>En Route</Status>\r\n    <Lastlocation>Departed Killester</Lastlocation>\r\n
+        \   <Duein>9</Duein>\r\n    <Late>2</Late>\r\n    <Exparrival>21:14</Exparrival>\r\n
+        \   <Expdepart>21:15</Expdepart>\r\n    <Scharrival>21:12</Scharrival>\r\n
+        \   <Schdepart>21:13</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
+        \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.21</Servertime>\r\n
+        \   <Traincode>E130 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Malahide</Origin>\r\n
+        \   <Destination>Greystones</Destination>\r\n    <Origintime>21:00</Origintime>\r\n
+        \   <Destinationtime>22:20</Destinationtime>\r\n    <Status>En Route</Status>\r\n
+        \   <Lastlocation>Departed Portmarnock</Lastlocation>\r\n    <Duein>20</Duein>\r\n
+        \   <Late>1</Late>\r\n    <Exparrival>21:25</Exparrival>\r\n    <Expdepart>21:26</Expdepart>\r\n
+        \   <Scharrival>21:24</Scharrival>\r\n    <Schdepart>21:25</Schdepart>\r\n
         \   <Direction>Southbound</Direction>\r\n    <Traintype>DART</Traintype>\r\n
         \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
-        \   <Servertime>2014-04-19T19:10:55.46</Servertime>\r\n    <Traincode>E229
+        \   <Servertime>2015-10-05T21:06:38.21</Servertime>\r\n    <Traincode>P670
         </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Malahide</Origin>\r\n
-        \   <Destination>Bray</Destination>\r\n    <Origintime>20:15</Origintime>\r\n
-        \   <Destinationtime>21:24</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>90</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>20:39</Exparrival>\r\n
-        \   <Expdepart>20:40</Expdepart>\r\n    <Scharrival>20:39</Scharrival>\r\n
-        \   <Schdepart>20:40</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Maynooth</Origin>\r\n
+        \   <Destination>Dublin Pearse</Destination>\r\n    <Origintime>20:47</Origintime>\r\n
+        \   <Destinationtime>21:34</Destinationtime>\r\n    <Status>En Route</Status>\r\n
+        \   <Lastlocation>Arrived Clonsilla</Lastlocation>\r\n    <Duein>28</Duein>\r\n
+        \   <Late>5</Late>\r\n    <Exparrival>21:33</Exparrival>\r\n    <Expdepart>21:34</Expdepart>\r\n
+        \   <Scharrival>21:28</Scharrival>\r\n    <Schdepart>21:29</Schdepart>\r\n
+        \   <Direction>Southbound</Direction>\r\n    <Traintype>Train</Traintype>\r\n
+        \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
+        \   <Servertime>2015-10-05T21:06:38.21</Servertime>\r\n    <Traincode>E231
+        </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Howth</Origin>\r\n    <Destination>Bray</Destination>\r\n
+        \   <Origintime>21:15</Origintime>\r\n    <Destinationtime>22:24</Destinationtime>\r\n
+        \   <Status>No Information</Status>\r\n    <Lastlocation />\r\n    <Duein>34</Duein>\r\n
+        \   <Late>0</Late>\r\n    <Exparrival>21:39</Exparrival>\r\n    <Expdepart>21:40</Expdepart>\r\n
+        \   <Scharrival>21:39</Scharrival>\r\n    <Schdepart>21:40</Schdepart>\r\n
+        \   <Direction>Southbound</Direction>\r\n    <Traintype>DART</Traintype>\r\n
+        \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
+        \   <Servertime>2015-10-05T21:06:38.21</Servertime>\r\n    <Traincode>P671
+        </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Maynooth</Origin>\r\n
+        \   <Destination>Dublin Pearse</Destination>\r\n    <Origintime>21:05</Origintime>\r\n
+        \   <Destinationtime>21:49</Destinationtime>\r\n    <Status>No Information</Status>\r\n
+        \   <Lastlocation />\r\n    <Duein>38</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>21:43</Exparrival>\r\n
+        \   <Expdepart>21:44</Expdepart>\r\n    <Scharrival>21:43</Scharrival>\r\n
+        \   <Schdepart>21:44</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
+        \   <Traintype>Train</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.21</Servertime>\r\n
+        \   <Traincode>E131 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Malahide</Origin>\r\n
+        \   <Destination>Greystones</Destination>\r\n    <Origintime>21:30</Origintime>\r\n
+        \   <Destinationtime>22:50</Destinationtime>\r\n    <Status>No Information</Status>\r\n
+        \   <Lastlocation />\r\n    <Duein>49</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>21:54</Exparrival>\r\n
+        \   <Expdepart>21:55</Expdepart>\r\n    <Scharrival>21:54</Scharrival>\r\n
+        \   <Schdepart>21:55</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
         \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.21</Servertime>\r\n
+        \   <Traincode>E232 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Howth</Origin>\r\n    <Destination>Bray</Destination>\r\n
+        \   <Origintime>21:45</Origintime>\r\n    <Destinationtime>22:54</Destinationtime>\r\n
+        \   <Status>No Information</Status>\r\n    <Lastlocation />\r\n    <Duein>64</Duein>\r\n
+        \   <Late>0</Late>\r\n    <Exparrival>22:09</Exparrival>\r\n    <Expdepart>22:10</Expdepart>\r\n
+        \   <Scharrival>22:09</Scharrival>\r\n    <Schdepart>22:10</Schdepart>\r\n
+        \   <Direction>Southbound</Direction>\r\n    <Traintype>DART</Traintype>\r\n
+        \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
+        \   <Servertime>2015-10-05T21:06:38.21</Servertime>\r\n    <Traincode>E710
+        </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Malahide</Origin>\r\n
+        \   <Destination>Dublin Connolly</Destination>\r\n    <Origintime>22:10</Origintime>\r\n
+        \   <Destinationtime>22:35</Destinationtime>\r\n    <Status>No Information</Status>\r\n
+        \   <Lastlocation />\r\n    <Duein>89</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>22:35</Exparrival>\r\n
+        \   <Expdepart>00:00</Expdepart>\r\n    <Scharrival>22:35</Scharrival>\r\n
+        \   <Schdepart>00:00</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
+        \   <Traintype>DART</Traintype>\r\n    <Locationtype>D</Locationtype>\r\n
         \ </objStationData>\r\n</ArrayOfObjStationData>"
     http_version: 
-  recorded_at: Sat, 19 Apr 2014 18:10:57 GMT
-recorded_with: VCR 2.9.0
+  recorded_at: Mon, 05 Oct 2015 20:06:37 GMT
+recorded_with: VCR 2.9.3

--- a/fixtures/vcr_cassettes/southbound_from.yml
+++ b/fixtures/vcr_cassettes/southbound_from.yml
@@ -25,217 +25,198 @@ http_interactions:
       Server:
       - ''
       Date:
-      - Sat, 19 Apr 2014 18:10:55 GMT
+      - Mon, 05 Oct 2015 20:06:37 GMT
       Content-Length:
-      - '16433'
+      - '14913'
     body:
       encoding: UTF-8
       string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ArrayOfObjStationData
         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-        xmlns=\"http://api.irishrail.ie/realtime/\">\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.79</Servertime>\r\n
-        \   <Traincode>D819 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Dublin Pearse</Origin>\r\n
-        \   <Destination>Drogheda</Destination>\r\n    <Origintime>19:13</Origintime>\r\n
-        \   <Destinationtime>20:16</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>10</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>19:19</Exparrival>\r\n
-        \   <Expdepart>19:20</Expdepart>\r\n    <Scharrival>19:19</Scharrival>\r\n
-        \   <Schdepart>19:20</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
+        xmlns=\"http://api.irishrail.ie/realtime/\">\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:39.137</Servertime>\r\n
+        \   <Traincode>E934 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:39</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Bray</Origin>\r\n    <Destination>Howth</Destination>\r\n
+        \   <Origintime>20:25</Origintime>\r\n    <Destinationtime>21:33</Destinationtime>\r\n
+        \   <Status>En Route</Status>\r\n    <Lastlocation>Departed Dublin Pearse</Lastlocation>\r\n
+        \   <Duein>5</Duein>\r\n    <Late>2</Late>\r\n    <Exparrival>21:10</Exparrival>\r\n
+        \   <Expdepart>21:11</Expdepart>\r\n    <Scharrival>21:08</Scharrival>\r\n
+        \   <Schdepart>21:09</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
+        \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:39.137</Servertime>\r\n
+        \   <Traincode>D931 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:39</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Dublin Pearse</Origin>\r\n
+        \   <Destination>Maynooth</Destination>\r\n    <Origintime>21:10</Origintime>\r\n
+        \   <Destinationtime>21:56</Destinationtime>\r\n    <Status>No Information</Status>\r\n
+        \   <Lastlocation />\r\n    <Duein>11</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>21:16</Exparrival>\r\n
+        \   <Expdepart>21:17</Expdepart>\r\n    <Scharrival>21:16</Scharrival>\r\n
+        \   <Schdepart>21:17</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
         \   <Traintype>Train</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.79</Servertime>\r\n
-        \   <Traincode>E930 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Greystones</Origin>\r\n
-        \   <Destination>Howth</Destination>\r\n    <Origintime>18:30</Origintime>\r\n
-        \   <Destinationtime>19:52</Destinationtime>\r\n    <Status>En Route</Status>\r\n
-        \   <Lastlocation>Arrived Booterstown</Lastlocation>\r\n    <Duein>17</Duein>\r\n
-        \   <Late>-1</Late>\r\n    <Exparrival>19:26</Exparrival>\r\n    <Expdepart>19:27</Expdepart>\r\n
-        \   <Scharrival>19:27</Scharrival>\r\n    <Schdepart>19:28</Schdepart>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:39.137</Servertime>\r\n
+        \   <Traincode>E830 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:39</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Greystones</Origin>\r\n
+        \   <Destination>Malahide</Destination>\r\n    <Origintime>20:30</Origintime>\r\n
+        \   <Destinationtime>21:50</Destinationtime>\r\n    <Status>En Route</Status>\r\n
+        \   <Lastlocation>Arrived Blackrock</Lastlocation>\r\n    <Duein>19</Duein>\r\n
+        \   <Late>1</Late>\r\n    <Exparrival>21:24</Exparrival>\r\n    <Expdepart>21:25</Expdepart>\r\n
+        \   <Scharrival>21:23</Scharrival>\r\n    <Schdepart>21:24</Schdepart>\r\n
         \   <Direction>Northbound</Direction>\r\n    <Traintype>DART</Traintype>\r\n
         \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
-        \   <Servertime>2014-04-19T19:10:55.79</Servertime>\r\n    <Traincode>E827
+        \   <Servertime>2015-10-05T21:06:39.137</Servertime>\r\n    <Traincode>D821
         </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Bray</Origin>\r\n    <Destination>Malahide</Destination>\r\n
-        \   <Origintime>18:55</Origintime>\r\n    <Destinationtime>20:05</Destinationtime>\r\n
-        \   <Status>En Route</Status>\r\n    <Lastlocation>Arrived Glenageary</Lastlocation>\r\n
-        \   <Duein>30</Duein>\r\n    <Late>1</Late>\r\n    <Exparrival>19:39</Exparrival>\r\n
-        \   <Expdepart>19:40</Expdepart>\r\n    <Scharrival>19:38</Scharrival>\r\n
-        \   <Schdepart>19:39</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
-        \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.79</Servertime>\r\n
-        \   <Traincode>D929 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Dublin Pearse</Origin>\r\n
-        \   <Destination>Maynooth</Destination>\r\n    <Origintime>19:40</Origintime>\r\n
-        \   <Destinationtime>20:26</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>37</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>19:46</Exparrival>\r\n
-        \   <Expdepart>19:47</Expdepart>\r\n    <Scharrival>19:46</Scharrival>\r\n
-        \   <Schdepart>19:47</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:39</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Dublin Pearse</Origin>\r\n
+        \   <Destination>Drogheda</Destination>\r\n    <Origintime>21:30</Origintime>\r\n
+        \   <Destinationtime>22:32</Destinationtime>\r\n    <Status>No Information</Status>\r\n
+        \   <Lastlocation />\r\n    <Duein>31</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>21:36</Exparrival>\r\n
+        \   <Expdepart>21:37</Expdepart>\r\n    <Scharrival>21:36</Scharrival>\r\n
+        \   <Schdepart>21:37</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
         \   <Traintype>Train</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.79</Servertime>\r\n
-        \   <Traincode>E931 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Bray</Origin>\r\n    <Destination>Howth</Destination>\r\n
-        \   <Origintime>19:10</Origintime>\r\n    <Destinationtime>20:18</Destinationtime>\r\n
-        \   <Status>No Information</Status>\r\n    <Lastlocation />\r\n    <Duein>44</Duein>\r\n
-        \   <Late>0</Late>\r\n    <Exparrival>19:53</Exparrival>\r\n    <Expdepart>19:54</Expdepart>\r\n
-        \   <Scharrival>19:53</Scharrival>\r\n    <Schdepart>19:54</Schdepart>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:39.137</Servertime>\r\n
+        \   <Traincode>E935 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:39</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Bray</Origin>\r\n    <Destination>Howth</Destination>\r\n
+        \   <Origintime>20:55</Origintime>\r\n    <Destinationtime>22:04</Destinationtime>\r\n
+        \   <Status>En Route</Status>\r\n    <Lastlocation>Departed Killiney</Lastlocation>\r\n
+        \   <Duein>35</Duein>\r\n    <Late>1</Late>\r\n    <Exparrival>21:39</Exparrival>\r\n
+        \   <Expdepart>21:41</Expdepart>\r\n    <Scharrival>21:38</Scharrival>\r\n
+        \   <Schdepart>21:40</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
+        \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:39.137</Servertime>\r\n
+        \   <Traincode>E831 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:39</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Greystones</Origin>\r\n
+        \   <Destination>Malahide</Destination>\r\n    <Origintime>21:00</Origintime>\r\n
+        \   <Destinationtime>22:20</Destinationtime>\r\n    <Status>En Route</Status>\r\n
+        \   <Lastlocation>Departed Greystones</Lastlocation>\r\n    <Duein>49</Duein>\r\n
+        \   <Late>1</Late>\r\n    <Exparrival>21:54</Exparrival>\r\n    <Expdepart>21:55</Expdepart>\r\n
+        \   <Scharrival>21:53</Scharrival>\r\n    <Schdepart>21:54</Schdepart>\r\n
         \   <Direction>Northbound</Direction>\r\n    <Traintype>DART</Traintype>\r\n
         \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
-        \   <Servertime>2014-04-19T19:10:55.79</Servertime>\r\n    <Traincode>E932
+        \   <Servertime>2015-10-05T21:06:39.137</Servertime>\r\n    <Traincode>E936
         </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Bray</Origin>\r\n    <Destination>Howth</Destination>\r\n
-        \   <Origintime>19:25</Origintime>\r\n    <Destinationtime>20:33</Destinationtime>\r\n
-        \   <Status>No Information</Status>\r\n    <Lastlocation />\r\n    <Duein>58</Duein>\r\n
-        \   <Late>0</Late>\r\n    <Exparrival>20:07</Exparrival>\r\n    <Expdepart>20:08</Expdepart>\r\n
-        \   <Scharrival>20:07</Scharrival>\r\n    <Schdepart>20:08</Schdepart>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:39</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Bray</Origin>\r\n    <Destination>Howth</Destination>\r\n
+        \   <Origintime>21:25</Origintime>\r\n    <Destinationtime>22:35</Destinationtime>\r\n
+        \   <Status>No Information</Status>\r\n    <Lastlocation />\r\n    <Duein>64</Duein>\r\n
+        \   <Late>0</Late>\r\n    <Exparrival>22:09</Exparrival>\r\n    <Expdepart>22:10</Expdepart>\r\n
+        \   <Scharrival>22:09</Scharrival>\r\n    <Schdepart>22:10</Schdepart>\r\n
         \   <Direction>Northbound</Direction>\r\n    <Traintype>DART</Traintype>\r\n
         \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
-        \   <Servertime>2014-04-19T19:10:55.79</Servertime>\r\n    <Traincode>D930
+        \   <Servertime>2015-10-05T21:06:39.137</Servertime>\r\n    <Traincode>D932
         </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Dublin Pearse</Origin>\r\n
-        \   <Destination>Maynooth</Destination>\r\n    <Origintime>20:08</Origintime>\r\n
-        \   <Destinationtime>20:54</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>64</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>20:13</Exparrival>\r\n
-        \   <Expdepart>20:14</Expdepart>\r\n    <Scharrival>20:13</Scharrival>\r\n
-        \   <Schdepart>20:14</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:39</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Dublin Pearse</Origin>\r\n
+        \   <Destination>Maynooth</Destination>\r\n    <Origintime>22:12</Origintime>\r\n
+        \   <Destinationtime>22:58</Destinationtime>\r\n    <Status>No Information</Status>\r\n
+        \   <Lastlocation />\r\n    <Duein>73</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>22:18</Exparrival>\r\n
+        \   <Expdepart>22:19</Expdepart>\r\n    <Scharrival>22:18</Scharrival>\r\n
+        \   <Schdepart>22:19</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
         \   <Traintype>Train</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.79</Servertime>\r\n
-        \   <Traincode>D820 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Dublin Pearse</Origin>\r\n
-        \   <Destination>Drogheda</Destination>\r\n    <Origintime>20:13</Origintime>\r\n
-        \   <Destinationtime>21:15</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>70</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>20:19</Exparrival>\r\n
-        \   <Expdepart>20:20</Expdepart>\r\n    <Scharrival>20:19</Scharrival>\r\n
-        \   <Schdepart>20:20</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
-        \   <Traintype>Train</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.79</Servertime>\r\n
-        \   <Traincode>E828 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Greystones</Origin>\r\n
-        \   <Destination>Malahide</Destination>\r\n    <Origintime>19:30</Origintime>\r\n
-        \   <Destinationtime>20:50</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>74</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>20:23</Exparrival>\r\n
-        \   <Expdepart>20:24</Expdepart>\r\n    <Scharrival>20:23</Scharrival>\r\n
-        \   <Schdepart>20:24</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:39.137</Servertime>\r\n
+        \   <Traincode>E832 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:39</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Greystones</Origin>\r\n
+        \   <Destination>Malahide</Destination>\r\n    <Origintime>21:30</Origintime>\r\n
+        \   <Destinationtime>22:50</Destinationtime>\r\n    <Status>No Information</Status>\r\n
+        \   <Lastlocation />\r\n    <Duein>78</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>22:23</Exparrival>\r\n
+        \   <Expdepart>22:24</Expdepart>\r\n    <Scharrival>22:23</Scharrival>\r\n
+        \   <Schdepart>22:24</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
         \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.79</Servertime>\r\n
-        \   <Traincode>E933 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Bray</Origin>\r\n    <Destination>Howth</Destination>\r\n
-        \   <Origintime>19:55</Origintime>\r\n    <Destinationtime>21:02</Destinationtime>\r\n
-        \   <Status>No Information</Status>\r\n    <Lastlocation />\r\n    <Duein>88</Duein>\r\n
-        \   <Late>0</Late>\r\n    <Exparrival>20:37</Exparrival>\r\n    <Expdepart>20:38</Expdepart>\r\n
-        \   <Scharrival>20:37</Scharrival>\r\n    <Schdepart>20:38</Schdepart>\r\n
-        \   <Direction>Northbound</Direction>\r\n    <Traintype>DART</Traintype>\r\n
-        \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
-        \   <Servertime>2014-04-19T19:10:55.79</Servertime>\r\n    <Traincode>P667
-        </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Maynooth</Origin>\r\n
-        \   <Destination>Dublin Pearse</Destination>\r\n    <Origintime>18:40</Origintime>\r\n
-        \   <Destinationtime>19:23</Destinationtime>\r\n    <Status>En Route</Status>\r\n
-        \   <Lastlocation>Departed Ashtown</Lastlocation>\r\n    <Duein>12</Duein>\r\n
-        \   <Late>3</Late>\r\n    <Exparrival>19:22</Exparrival>\r\n    <Expdepart>19:22</Expdepart>\r\n
-        \   <Scharrival>19:18</Scharrival>\r\n    <Schdepart>19:19</Schdepart>\r\n
-        \   <Direction>Southbound</Direction>\r\n    <Traintype>Train</Traintype>\r\n
-        \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
-        \   <Servertime>2014-04-19T19:10:55.79</Servertime>\r\n    <Traincode>E126
-        </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Howth</Origin>\r\n    <Destination>Greystones</Destination>\r\n
-        \   <Origintime>19:00</Origintime>\r\n    <Destinationtime>20:20</Destinationtime>\r\n
-        \   <Status>En Route</Status>\r\n    <Lastlocation>Departed Howth Junction</Lastlocation>\r\n
-        \   <Duein>15</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>19:24</Exparrival>\r\n
-        \   <Expdepart>19:25</Expdepart>\r\n    <Scharrival>19:24</Scharrival>\r\n
-        \   <Schdepart>19:25</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
-        \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.79</Servertime>\r\n
-        \   <Traincode>E227 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Malahide</Origin>\r\n
-        \   <Destination>Bray</Destination>\r\n    <Origintime>19:15</Origintime>\r\n
-        \   <Destinationtime>20:24</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>30</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>19:39</Exparrival>\r\n
-        \   <Expdepart>19:40</Expdepart>\r\n    <Scharrival>19:39</Scharrival>\r\n
-        \   <Schdepart>19:40</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
-        \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.79</Servertime>\r\n
-        \   <Traincode>P622 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Drogheda</Origin>\r\n
-        \   <Destination>Dublin Pearse</Destination>\r\n    <Origintime>18:50</Origintime>\r\n
-        \   <Destinationtime>19:51</Destinationtime>\r\n    <Status>En Route</Status>\r\n
-        \   <Lastlocation>Departed Balbriggan</Lastlocation>\r\n    <Duein>37</Duein>\r\n
-        \   <Late>1</Late>\r\n    <Exparrival>19:46</Exparrival>\r\n    <Expdepart>19:47</Expdepart>\r\n
-        \   <Scharrival>19:45</Scharrival>\r\n    <Schdepart>19:46</Schdepart>\r\n
-        \   <Direction>Southbound</Direction>\r\n    <Traintype>Train</Traintype>\r\n
-        \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
-        \   <Servertime>2014-04-19T19:10:55.79</Servertime>\r\n    <Traincode>E252
-        </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Howth</Origin>\r\n    <Destination>Bray</Destination>\r\n
-        \   <Origintime>19:30</Origintime>\r\n    <Destinationtime>20:39</Destinationtime>\r\n
-        \   <Status>No Information</Status>\r\n    <Lastlocation />\r\n    <Duein>45</Duein>\r\n
-        \   <Late>0</Late>\r\n    <Exparrival>19:54</Exparrival>\r\n    <Expdepart>19:55</Expdepart>\r\n
-        \   <Scharrival>19:54</Scharrival>\r\n    <Schdepart>19:55</Schdepart>\r\n
-        \   <Direction>Southbound</Direction>\r\n    <Traintype>DART</Traintype>\r\n
-        \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
-        \   <Servertime>2014-04-19T19:10:55.79</Servertime>\r\n    <Traincode>E228
-        </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Malahide</Origin>\r\n
-        \   <Destination>Bray</Destination>\r\n    <Origintime>19:45</Origintime>\r\n
-        \   <Destinationtime>20:54</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>60</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>20:09</Exparrival>\r\n
-        \   <Expdepart>20:10</Expdepart>\r\n    <Scharrival>20:09</Scharrival>\r\n
-        \   <Schdepart>20:10</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
-        \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.79</Servertime>\r\n
-        \   <Traincode>A133 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Belfast Central</Origin>\r\n
-        \   <Destination>Dublin Connolly</Destination>\r\n    <Origintime>18:05</Origintime>\r\n
-        \   <Destinationtime>20:15</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>65</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>20:15</Exparrival>\r\n
-        \   <Expdepart>00:00</Expdepart>\r\n    <Scharrival>20:15</Scharrival>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:39.137</Servertime>\r\n
+        \   <Traincode>A913 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:39</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Sligo</Origin>\r\n    <Destination>Dublin
+        Connolly</Destination>\r\n    <Origintime>18:00</Origintime>\r\n    <Destinationtime>21:08</Destinationtime>\r\n
+        \   <Status>En Route</Status>\r\n    <Lastlocation>Arrived Drumcondra</Lastlocation>\r\n
+        \   <Duein>6</Duein>\r\n    <Late>4</Late>\r\n    <Exparrival>21:12</Exparrival>\r\n
+        \   <Expdepart>00:00</Expdepart>\r\n    <Scharrival>21:08</Scharrival>\r\n
         \   <Schdepart>00:00</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
         \   <Traintype>Train</Traintype>\r\n    <Locationtype>D</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.79</Servertime>\r\n
-        \   <Traincode>P668 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Maynooth</Origin>\r\n
-        \   <Destination>Dublin Pearse</Destination>\r\n    <Origintime>19:41</Origintime>\r\n
-        \   <Destinationtime>20:26</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>71</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>20:20</Exparrival>\r\n
-        \   <Expdepart>20:21</Expdepart>\r\n    <Scharrival>20:20</Scharrival>\r\n
-        \   <Schdepart>20:21</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
-        \   <Traintype>Train</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.79</Servertime>\r\n
-        \   <Traincode>E128 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Howth</Origin>\r\n    <Destination>Greystones</Destination>\r\n
-        \   <Origintime>20:00</Origintime>\r\n    <Destinationtime>21:20</Destinationtime>\r\n
-        \   <Status>No Information</Status>\r\n    <Lastlocation />\r\n    <Duein>75</Duein>\r\n
-        \   <Late>0</Late>\r\n    <Exparrival>20:24</Exparrival>\r\n    <Expdepart>20:25</Expdepart>\r\n
-        \   <Scharrival>20:24</Scharrival>\r\n    <Schdepart>20:25</Schdepart>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:39.137</Servertime>\r\n
+        \   <Traincode>E230 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:39</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Howth</Origin>\r\n    <Destination>Bray</Destination>\r\n
+        \   <Origintime>20:45</Origintime>\r\n    <Destinationtime>21:57</Destinationtime>\r\n
+        \   <Status>En Route</Status>\r\n    <Lastlocation>Departed Killester</Lastlocation>\r\n
+        \   <Duein>9</Duein>\r\n    <Late>2</Late>\r\n    <Exparrival>21:14</Exparrival>\r\n
+        \   <Expdepart>21:15</Expdepart>\r\n    <Scharrival>21:12</Scharrival>\r\n
+        \   <Schdepart>21:13</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
+        \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:39.137</Servertime>\r\n
+        \   <Traincode>E130 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:39</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Malahide</Origin>\r\n
+        \   <Destination>Greystones</Destination>\r\n    <Origintime>21:00</Origintime>\r\n
+        \   <Destinationtime>22:20</Destinationtime>\r\n    <Status>En Route</Status>\r\n
+        \   <Lastlocation>Departed Portmarnock</Lastlocation>\r\n    <Duein>20</Duein>\r\n
+        \   <Late>1</Late>\r\n    <Exparrival>21:25</Exparrival>\r\n    <Expdepart>21:26</Expdepart>\r\n
+        \   <Scharrival>21:24</Scharrival>\r\n    <Schdepart>21:25</Schdepart>\r\n
         \   <Direction>Southbound</Direction>\r\n    <Traintype>DART</Traintype>\r\n
         \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
-        \   <Servertime>2014-04-19T19:10:55.79</Servertime>\r\n    <Traincode>E229
+        \   <Servertime>2015-10-05T21:06:39.137</Servertime>\r\n    <Traincode>P670
         </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Malahide</Origin>\r\n
-        \   <Destination>Bray</Destination>\r\n    <Origintime>20:15</Origintime>\r\n
-        \   <Destinationtime>21:24</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>90</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>20:39</Exparrival>\r\n
-        \   <Expdepart>20:40</Expdepart>\r\n    <Scharrival>20:39</Scharrival>\r\n
-        \   <Schdepart>20:40</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:39</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Maynooth</Origin>\r\n
+        \   <Destination>Dublin Pearse</Destination>\r\n    <Origintime>20:47</Origintime>\r\n
+        \   <Destinationtime>21:34</Destinationtime>\r\n    <Status>En Route</Status>\r\n
+        \   <Lastlocation>Arrived Clonsilla</Lastlocation>\r\n    <Duein>28</Duein>\r\n
+        \   <Late>5</Late>\r\n    <Exparrival>21:33</Exparrival>\r\n    <Expdepart>21:34</Expdepart>\r\n
+        \   <Scharrival>21:28</Scharrival>\r\n    <Schdepart>21:29</Schdepart>\r\n
+        \   <Direction>Southbound</Direction>\r\n    <Traintype>Train</Traintype>\r\n
+        \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
+        \   <Servertime>2015-10-05T21:06:39.137</Servertime>\r\n    <Traincode>E231
+        </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:39</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Howth</Origin>\r\n    <Destination>Bray</Destination>\r\n
+        \   <Origintime>21:15</Origintime>\r\n    <Destinationtime>22:24</Destinationtime>\r\n
+        \   <Status>No Information</Status>\r\n    <Lastlocation />\r\n    <Duein>34</Duein>\r\n
+        \   <Late>0</Late>\r\n    <Exparrival>21:39</Exparrival>\r\n    <Expdepart>21:40</Expdepart>\r\n
+        \   <Scharrival>21:39</Scharrival>\r\n    <Schdepart>21:40</Schdepart>\r\n
+        \   <Direction>Southbound</Direction>\r\n    <Traintype>DART</Traintype>\r\n
+        \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
+        \   <Servertime>2015-10-05T21:06:39.137</Servertime>\r\n    <Traincode>P671
+        </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:39</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Maynooth</Origin>\r\n
+        \   <Destination>Dublin Pearse</Destination>\r\n    <Origintime>21:05</Origintime>\r\n
+        \   <Destinationtime>21:49</Destinationtime>\r\n    <Status>No Information</Status>\r\n
+        \   <Lastlocation />\r\n    <Duein>38</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>21:43</Exparrival>\r\n
+        \   <Expdepart>21:44</Expdepart>\r\n    <Scharrival>21:43</Scharrival>\r\n
+        \   <Schdepart>21:44</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
+        \   <Traintype>Train</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:39.137</Servertime>\r\n
+        \   <Traincode>E131 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:39</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Malahide</Origin>\r\n
+        \   <Destination>Greystones</Destination>\r\n    <Origintime>21:30</Origintime>\r\n
+        \   <Destinationtime>22:50</Destinationtime>\r\n    <Status>No Information</Status>\r\n
+        \   <Lastlocation />\r\n    <Duein>49</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>21:54</Exparrival>\r\n
+        \   <Expdepart>21:55</Expdepart>\r\n    <Scharrival>21:54</Scharrival>\r\n
+        \   <Schdepart>21:55</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
         \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:39.137</Servertime>\r\n
+        \   <Traincode>E232 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:39</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Howth</Origin>\r\n    <Destination>Bray</Destination>\r\n
+        \   <Origintime>21:45</Origintime>\r\n    <Destinationtime>22:54</Destinationtime>\r\n
+        \   <Status>No Information</Status>\r\n    <Lastlocation />\r\n    <Duein>64</Duein>\r\n
+        \   <Late>0</Late>\r\n    <Exparrival>22:09</Exparrival>\r\n    <Expdepart>22:10</Expdepart>\r\n
+        \   <Scharrival>22:09</Scharrival>\r\n    <Schdepart>22:10</Schdepart>\r\n
+        \   <Direction>Southbound</Direction>\r\n    <Traintype>DART</Traintype>\r\n
+        \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
+        \   <Servertime>2015-10-05T21:06:39.137</Servertime>\r\n    <Traincode>E710
+        </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:39</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Malahide</Origin>\r\n
+        \   <Destination>Dublin Connolly</Destination>\r\n    <Origintime>22:10</Origintime>\r\n
+        \   <Destinationtime>22:35</Destinationtime>\r\n    <Status>No Information</Status>\r\n
+        \   <Lastlocation />\r\n    <Duein>89</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>22:35</Exparrival>\r\n
+        \   <Expdepart>00:00</Expdepart>\r\n    <Scharrival>22:35</Scharrival>\r\n
+        \   <Schdepart>00:00</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
+        \   <Traintype>DART</Traintype>\r\n    <Locationtype>D</Locationtype>\r\n
         \ </objStationData>\r\n</ArrayOfObjStationData>"
     http_version: 
-  recorded_at: Sat, 19 Apr 2014 18:10:57 GMT
-recorded_with: VCR 2.9.0
+  recorded_at: Mon, 05 Oct 2015 20:06:38 GMT
+recorded_with: VCR 2.9.3

--- a/fixtures/vcr_cassettes/station.yml
+++ b/fixtures/vcr_cassettes/station.yml
@@ -25,217 +25,198 @@ http_interactions:
       Server:
       - ''
       Date:
-      - Sat, 19 Apr 2014 18:10:56 GMT
+      - Mon, 05 Oct 2015 20:06:37 GMT
       Content-Length:
-      - '16433'
+      - '14913'
     body:
       encoding: UTF-8
       string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ArrayOfObjStationData
         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-        xmlns=\"http://api.irishrail.ie/realtime/\">\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.93</Servertime>\r\n
-        \   <Traincode>D819 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Dublin Pearse</Origin>\r\n
-        \   <Destination>Drogheda</Destination>\r\n    <Origintime>19:13</Origintime>\r\n
-        \   <Destinationtime>20:16</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>10</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>19:19</Exparrival>\r\n
-        \   <Expdepart>19:20</Expdepart>\r\n    <Scharrival>19:19</Scharrival>\r\n
-        \   <Schdepart>19:20</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
+        xmlns=\"http://api.irishrail.ie/realtime/\">\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.937</Servertime>\r\n
+        \   <Traincode>E934 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Bray</Origin>\r\n    <Destination>Howth</Destination>\r\n
+        \   <Origintime>20:25</Origintime>\r\n    <Destinationtime>21:33</Destinationtime>\r\n
+        \   <Status>En Route</Status>\r\n    <Lastlocation>Departed Dublin Pearse</Lastlocation>\r\n
+        \   <Duein>5</Duein>\r\n    <Late>2</Late>\r\n    <Exparrival>21:10</Exparrival>\r\n
+        \   <Expdepart>21:11</Expdepart>\r\n    <Scharrival>21:08</Scharrival>\r\n
+        \   <Schdepart>21:09</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
+        \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.937</Servertime>\r\n
+        \   <Traincode>D931 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Dublin Pearse</Origin>\r\n
+        \   <Destination>Maynooth</Destination>\r\n    <Origintime>21:10</Origintime>\r\n
+        \   <Destinationtime>21:56</Destinationtime>\r\n    <Status>No Information</Status>\r\n
+        \   <Lastlocation />\r\n    <Duein>11</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>21:16</Exparrival>\r\n
+        \   <Expdepart>21:17</Expdepart>\r\n    <Scharrival>21:16</Scharrival>\r\n
+        \   <Schdepart>21:17</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
         \   <Traintype>Train</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.93</Servertime>\r\n
-        \   <Traincode>E930 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Greystones</Origin>\r\n
-        \   <Destination>Howth</Destination>\r\n    <Origintime>18:30</Origintime>\r\n
-        \   <Destinationtime>19:52</Destinationtime>\r\n    <Status>En Route</Status>\r\n
-        \   <Lastlocation>Arrived Booterstown</Lastlocation>\r\n    <Duein>17</Duein>\r\n
-        \   <Late>-1</Late>\r\n    <Exparrival>19:26</Exparrival>\r\n    <Expdepart>19:27</Expdepart>\r\n
-        \   <Scharrival>19:27</Scharrival>\r\n    <Schdepart>19:28</Schdepart>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.937</Servertime>\r\n
+        \   <Traincode>E830 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Greystones</Origin>\r\n
+        \   <Destination>Malahide</Destination>\r\n    <Origintime>20:30</Origintime>\r\n
+        \   <Destinationtime>21:50</Destinationtime>\r\n    <Status>En Route</Status>\r\n
+        \   <Lastlocation>Arrived Blackrock</Lastlocation>\r\n    <Duein>19</Duein>\r\n
+        \   <Late>1</Late>\r\n    <Exparrival>21:24</Exparrival>\r\n    <Expdepart>21:25</Expdepart>\r\n
+        \   <Scharrival>21:23</Scharrival>\r\n    <Schdepart>21:24</Schdepart>\r\n
         \   <Direction>Northbound</Direction>\r\n    <Traintype>DART</Traintype>\r\n
         \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
-        \   <Servertime>2014-04-19T19:10:55.93</Servertime>\r\n    <Traincode>E827
+        \   <Servertime>2015-10-05T21:06:38.937</Servertime>\r\n    <Traincode>D821
         </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Bray</Origin>\r\n    <Destination>Malahide</Destination>\r\n
-        \   <Origintime>18:55</Origintime>\r\n    <Destinationtime>20:05</Destinationtime>\r\n
-        \   <Status>En Route</Status>\r\n    <Lastlocation>Arrived Glenageary</Lastlocation>\r\n
-        \   <Duein>30</Duein>\r\n    <Late>1</Late>\r\n    <Exparrival>19:39</Exparrival>\r\n
-        \   <Expdepart>19:40</Expdepart>\r\n    <Scharrival>19:38</Scharrival>\r\n
-        \   <Schdepart>19:39</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
-        \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.93</Servertime>\r\n
-        \   <Traincode>D929 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Dublin Pearse</Origin>\r\n
-        \   <Destination>Maynooth</Destination>\r\n    <Origintime>19:40</Origintime>\r\n
-        \   <Destinationtime>20:26</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>37</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>19:46</Exparrival>\r\n
-        \   <Expdepart>19:47</Expdepart>\r\n    <Scharrival>19:46</Scharrival>\r\n
-        \   <Schdepart>19:47</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Dublin Pearse</Origin>\r\n
+        \   <Destination>Drogheda</Destination>\r\n    <Origintime>21:30</Origintime>\r\n
+        \   <Destinationtime>22:32</Destinationtime>\r\n    <Status>No Information</Status>\r\n
+        \   <Lastlocation />\r\n    <Duein>31</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>21:36</Exparrival>\r\n
+        \   <Expdepart>21:37</Expdepart>\r\n    <Scharrival>21:36</Scharrival>\r\n
+        \   <Schdepart>21:37</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
         \   <Traintype>Train</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.93</Servertime>\r\n
-        \   <Traincode>E931 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Bray</Origin>\r\n    <Destination>Howth</Destination>\r\n
-        \   <Origintime>19:10</Origintime>\r\n    <Destinationtime>20:18</Destinationtime>\r\n
-        \   <Status>No Information</Status>\r\n    <Lastlocation />\r\n    <Duein>44</Duein>\r\n
-        \   <Late>0</Late>\r\n    <Exparrival>19:53</Exparrival>\r\n    <Expdepart>19:54</Expdepart>\r\n
-        \   <Scharrival>19:53</Scharrival>\r\n    <Schdepart>19:54</Schdepart>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.937</Servertime>\r\n
+        \   <Traincode>E935 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Bray</Origin>\r\n    <Destination>Howth</Destination>\r\n
+        \   <Origintime>20:55</Origintime>\r\n    <Destinationtime>22:04</Destinationtime>\r\n
+        \   <Status>En Route</Status>\r\n    <Lastlocation>Departed Killiney</Lastlocation>\r\n
+        \   <Duein>35</Duein>\r\n    <Late>1</Late>\r\n    <Exparrival>21:39</Exparrival>\r\n
+        \   <Expdepart>21:41</Expdepart>\r\n    <Scharrival>21:38</Scharrival>\r\n
+        \   <Schdepart>21:40</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
+        \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.937</Servertime>\r\n
+        \   <Traincode>E831 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Greystones</Origin>\r\n
+        \   <Destination>Malahide</Destination>\r\n    <Origintime>21:00</Origintime>\r\n
+        \   <Destinationtime>22:20</Destinationtime>\r\n    <Status>En Route</Status>\r\n
+        \   <Lastlocation>Departed Greystones</Lastlocation>\r\n    <Duein>49</Duein>\r\n
+        \   <Late>1</Late>\r\n    <Exparrival>21:54</Exparrival>\r\n    <Expdepart>21:55</Expdepart>\r\n
+        \   <Scharrival>21:53</Scharrival>\r\n    <Schdepart>21:54</Schdepart>\r\n
         \   <Direction>Northbound</Direction>\r\n    <Traintype>DART</Traintype>\r\n
         \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
-        \   <Servertime>2014-04-19T19:10:55.93</Servertime>\r\n    <Traincode>E932
+        \   <Servertime>2015-10-05T21:06:38.937</Servertime>\r\n    <Traincode>E936
         </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Bray</Origin>\r\n    <Destination>Howth</Destination>\r\n
-        \   <Origintime>19:25</Origintime>\r\n    <Destinationtime>20:33</Destinationtime>\r\n
-        \   <Status>No Information</Status>\r\n    <Lastlocation />\r\n    <Duein>58</Duein>\r\n
-        \   <Late>0</Late>\r\n    <Exparrival>20:07</Exparrival>\r\n    <Expdepart>20:08</Expdepart>\r\n
-        \   <Scharrival>20:07</Scharrival>\r\n    <Schdepart>20:08</Schdepart>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Bray</Origin>\r\n    <Destination>Howth</Destination>\r\n
+        \   <Origintime>21:25</Origintime>\r\n    <Destinationtime>22:35</Destinationtime>\r\n
+        \   <Status>No Information</Status>\r\n    <Lastlocation />\r\n    <Duein>64</Duein>\r\n
+        \   <Late>0</Late>\r\n    <Exparrival>22:09</Exparrival>\r\n    <Expdepart>22:10</Expdepart>\r\n
+        \   <Scharrival>22:09</Scharrival>\r\n    <Schdepart>22:10</Schdepart>\r\n
         \   <Direction>Northbound</Direction>\r\n    <Traintype>DART</Traintype>\r\n
         \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
-        \   <Servertime>2014-04-19T19:10:55.93</Servertime>\r\n    <Traincode>D930
+        \   <Servertime>2015-10-05T21:06:38.937</Servertime>\r\n    <Traincode>D932
         </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Dublin Pearse</Origin>\r\n
-        \   <Destination>Maynooth</Destination>\r\n    <Origintime>20:08</Origintime>\r\n
-        \   <Destinationtime>20:54</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>64</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>20:13</Exparrival>\r\n
-        \   <Expdepart>20:14</Expdepart>\r\n    <Scharrival>20:13</Scharrival>\r\n
-        \   <Schdepart>20:14</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Dublin Pearse</Origin>\r\n
+        \   <Destination>Maynooth</Destination>\r\n    <Origintime>22:12</Origintime>\r\n
+        \   <Destinationtime>22:58</Destinationtime>\r\n    <Status>No Information</Status>\r\n
+        \   <Lastlocation />\r\n    <Duein>73</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>22:18</Exparrival>\r\n
+        \   <Expdepart>22:19</Expdepart>\r\n    <Scharrival>22:18</Scharrival>\r\n
+        \   <Schdepart>22:19</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
         \   <Traintype>Train</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.93</Servertime>\r\n
-        \   <Traincode>D820 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Dublin Pearse</Origin>\r\n
-        \   <Destination>Drogheda</Destination>\r\n    <Origintime>20:13</Origintime>\r\n
-        \   <Destinationtime>21:15</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>70</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>20:19</Exparrival>\r\n
-        \   <Expdepart>20:20</Expdepart>\r\n    <Scharrival>20:19</Scharrival>\r\n
-        \   <Schdepart>20:20</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
-        \   <Traintype>Train</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.93</Servertime>\r\n
-        \   <Traincode>E828 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Greystones</Origin>\r\n
-        \   <Destination>Malahide</Destination>\r\n    <Origintime>19:30</Origintime>\r\n
-        \   <Destinationtime>20:50</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>74</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>20:23</Exparrival>\r\n
-        \   <Expdepart>20:24</Expdepart>\r\n    <Scharrival>20:23</Scharrival>\r\n
-        \   <Schdepart>20:24</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.937</Servertime>\r\n
+        \   <Traincode>E832 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Greystones</Origin>\r\n
+        \   <Destination>Malahide</Destination>\r\n    <Origintime>21:30</Origintime>\r\n
+        \   <Destinationtime>22:50</Destinationtime>\r\n    <Status>No Information</Status>\r\n
+        \   <Lastlocation />\r\n    <Duein>78</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>22:23</Exparrival>\r\n
+        \   <Expdepart>22:24</Expdepart>\r\n    <Scharrival>22:23</Scharrival>\r\n
+        \   <Schdepart>22:24</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
         \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.93</Servertime>\r\n
-        \   <Traincode>E933 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Bray</Origin>\r\n    <Destination>Howth</Destination>\r\n
-        \   <Origintime>19:55</Origintime>\r\n    <Destinationtime>21:02</Destinationtime>\r\n
-        \   <Status>No Information</Status>\r\n    <Lastlocation />\r\n    <Duein>88</Duein>\r\n
-        \   <Late>0</Late>\r\n    <Exparrival>20:37</Exparrival>\r\n    <Expdepart>20:38</Expdepart>\r\n
-        \   <Scharrival>20:37</Scharrival>\r\n    <Schdepart>20:38</Schdepart>\r\n
-        \   <Direction>Northbound</Direction>\r\n    <Traintype>DART</Traintype>\r\n
-        \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
-        \   <Servertime>2014-04-19T19:10:55.93</Servertime>\r\n    <Traincode>P667
-        </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Maynooth</Origin>\r\n
-        \   <Destination>Dublin Pearse</Destination>\r\n    <Origintime>18:40</Origintime>\r\n
-        \   <Destinationtime>19:23</Destinationtime>\r\n    <Status>En Route</Status>\r\n
-        \   <Lastlocation>Departed Ashtown</Lastlocation>\r\n    <Duein>12</Duein>\r\n
-        \   <Late>3</Late>\r\n    <Exparrival>19:22</Exparrival>\r\n    <Expdepart>19:22</Expdepart>\r\n
-        \   <Scharrival>19:18</Scharrival>\r\n    <Schdepart>19:19</Schdepart>\r\n
-        \   <Direction>Southbound</Direction>\r\n    <Traintype>Train</Traintype>\r\n
-        \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
-        \   <Servertime>2014-04-19T19:10:55.93</Servertime>\r\n    <Traincode>E126
-        </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Howth</Origin>\r\n    <Destination>Greystones</Destination>\r\n
-        \   <Origintime>19:00</Origintime>\r\n    <Destinationtime>20:20</Destinationtime>\r\n
-        \   <Status>En Route</Status>\r\n    <Lastlocation>Departed Howth Junction</Lastlocation>\r\n
-        \   <Duein>15</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>19:24</Exparrival>\r\n
-        \   <Expdepart>19:25</Expdepart>\r\n    <Scharrival>19:24</Scharrival>\r\n
-        \   <Schdepart>19:25</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
-        \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.93</Servertime>\r\n
-        \   <Traincode>E227 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Malahide</Origin>\r\n
-        \   <Destination>Bray</Destination>\r\n    <Origintime>19:15</Origintime>\r\n
-        \   <Destinationtime>20:24</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>30</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>19:39</Exparrival>\r\n
-        \   <Expdepart>19:40</Expdepart>\r\n    <Scharrival>19:39</Scharrival>\r\n
-        \   <Schdepart>19:40</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
-        \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.93</Servertime>\r\n
-        \   <Traincode>P622 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Drogheda</Origin>\r\n
-        \   <Destination>Dublin Pearse</Destination>\r\n    <Origintime>18:50</Origintime>\r\n
-        \   <Destinationtime>19:51</Destinationtime>\r\n    <Status>En Route</Status>\r\n
-        \   <Lastlocation>Departed Balbriggan</Lastlocation>\r\n    <Duein>37</Duein>\r\n
-        \   <Late>1</Late>\r\n    <Exparrival>19:46</Exparrival>\r\n    <Expdepart>19:47</Expdepart>\r\n
-        \   <Scharrival>19:45</Scharrival>\r\n    <Schdepart>19:46</Schdepart>\r\n
-        \   <Direction>Southbound</Direction>\r\n    <Traintype>Train</Traintype>\r\n
-        \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
-        \   <Servertime>2014-04-19T19:10:55.93</Servertime>\r\n    <Traincode>E252
-        </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Howth</Origin>\r\n    <Destination>Bray</Destination>\r\n
-        \   <Origintime>19:30</Origintime>\r\n    <Destinationtime>20:39</Destinationtime>\r\n
-        \   <Status>No Information</Status>\r\n    <Lastlocation />\r\n    <Duein>45</Duein>\r\n
-        \   <Late>0</Late>\r\n    <Exparrival>19:54</Exparrival>\r\n    <Expdepart>19:55</Expdepart>\r\n
-        \   <Scharrival>19:54</Scharrival>\r\n    <Schdepart>19:55</Schdepart>\r\n
-        \   <Direction>Southbound</Direction>\r\n    <Traintype>DART</Traintype>\r\n
-        \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
-        \   <Servertime>2014-04-19T19:10:55.93</Servertime>\r\n    <Traincode>E228
-        </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Malahide</Origin>\r\n
-        \   <Destination>Bray</Destination>\r\n    <Origintime>19:45</Origintime>\r\n
-        \   <Destinationtime>20:54</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>60</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>20:09</Exparrival>\r\n
-        \   <Expdepart>20:10</Expdepart>\r\n    <Scharrival>20:09</Scharrival>\r\n
-        \   <Schdepart>20:10</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
-        \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.93</Servertime>\r\n
-        \   <Traincode>A133 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Belfast Central</Origin>\r\n
-        \   <Destination>Dublin Connolly</Destination>\r\n    <Origintime>18:05</Origintime>\r\n
-        \   <Destinationtime>20:15</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>65</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>20:15</Exparrival>\r\n
-        \   <Expdepart>00:00</Expdepart>\r\n    <Scharrival>20:15</Scharrival>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.937</Servertime>\r\n
+        \   <Traincode>A913 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Sligo</Origin>\r\n    <Destination>Dublin
+        Connolly</Destination>\r\n    <Origintime>18:00</Origintime>\r\n    <Destinationtime>21:08</Destinationtime>\r\n
+        \   <Status>En Route</Status>\r\n    <Lastlocation>Arrived Drumcondra</Lastlocation>\r\n
+        \   <Duein>6</Duein>\r\n    <Late>4</Late>\r\n    <Exparrival>21:12</Exparrival>\r\n
+        \   <Expdepart>00:00</Expdepart>\r\n    <Scharrival>21:08</Scharrival>\r\n
         \   <Schdepart>00:00</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
         \   <Traintype>Train</Traintype>\r\n    <Locationtype>D</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.93</Servertime>\r\n
-        \   <Traincode>P668 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Maynooth</Origin>\r\n
-        \   <Destination>Dublin Pearse</Destination>\r\n    <Origintime>19:41</Origintime>\r\n
-        \   <Destinationtime>20:26</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>71</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>20:20</Exparrival>\r\n
-        \   <Expdepart>20:21</Expdepart>\r\n    <Scharrival>20:20</Scharrival>\r\n
-        \   <Schdepart>20:21</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
-        \   <Traintype>Train</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.93</Servertime>\r\n
-        \   <Traincode>E128 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Howth</Origin>\r\n    <Destination>Greystones</Destination>\r\n
-        \   <Origintime>20:00</Origintime>\r\n    <Destinationtime>21:20</Destinationtime>\r\n
-        \   <Status>No Information</Status>\r\n    <Lastlocation />\r\n    <Duein>75</Duein>\r\n
-        \   <Late>0</Late>\r\n    <Exparrival>20:24</Exparrival>\r\n    <Expdepart>20:25</Expdepart>\r\n
-        \   <Scharrival>20:24</Scharrival>\r\n    <Schdepart>20:25</Schdepart>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.937</Servertime>\r\n
+        \   <Traincode>E230 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Howth</Origin>\r\n    <Destination>Bray</Destination>\r\n
+        \   <Origintime>20:45</Origintime>\r\n    <Destinationtime>21:57</Destinationtime>\r\n
+        \   <Status>En Route</Status>\r\n    <Lastlocation>Departed Killester</Lastlocation>\r\n
+        \   <Duein>9</Duein>\r\n    <Late>2</Late>\r\n    <Exparrival>21:14</Exparrival>\r\n
+        \   <Expdepart>21:15</Expdepart>\r\n    <Scharrival>21:12</Scharrival>\r\n
+        \   <Schdepart>21:13</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
+        \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.937</Servertime>\r\n
+        \   <Traincode>E130 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Malahide</Origin>\r\n
+        \   <Destination>Greystones</Destination>\r\n    <Origintime>21:00</Origintime>\r\n
+        \   <Destinationtime>22:20</Destinationtime>\r\n    <Status>En Route</Status>\r\n
+        \   <Lastlocation>Departed Portmarnock</Lastlocation>\r\n    <Duein>20</Duein>\r\n
+        \   <Late>1</Late>\r\n    <Exparrival>21:25</Exparrival>\r\n    <Expdepart>21:26</Expdepart>\r\n
+        \   <Scharrival>21:24</Scharrival>\r\n    <Schdepart>21:25</Schdepart>\r\n
         \   <Direction>Southbound</Direction>\r\n    <Traintype>DART</Traintype>\r\n
         \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
-        \   <Servertime>2014-04-19T19:10:55.93</Servertime>\r\n    <Traincode>E229
+        \   <Servertime>2015-10-05T21:06:38.937</Servertime>\r\n    <Traincode>P670
         </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Malahide</Origin>\r\n
-        \   <Destination>Bray</Destination>\r\n    <Origintime>20:15</Origintime>\r\n
-        \   <Destinationtime>21:24</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>90</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>20:39</Exparrival>\r\n
-        \   <Expdepart>20:40</Expdepart>\r\n    <Scharrival>20:39</Scharrival>\r\n
-        \   <Schdepart>20:40</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Maynooth</Origin>\r\n
+        \   <Destination>Dublin Pearse</Destination>\r\n    <Origintime>20:47</Origintime>\r\n
+        \   <Destinationtime>21:34</Destinationtime>\r\n    <Status>En Route</Status>\r\n
+        \   <Lastlocation>Arrived Clonsilla</Lastlocation>\r\n    <Duein>28</Duein>\r\n
+        \   <Late>5</Late>\r\n    <Exparrival>21:33</Exparrival>\r\n    <Expdepart>21:34</Expdepart>\r\n
+        \   <Scharrival>21:28</Scharrival>\r\n    <Schdepart>21:29</Schdepart>\r\n
+        \   <Direction>Southbound</Direction>\r\n    <Traintype>Train</Traintype>\r\n
+        \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
+        \   <Servertime>2015-10-05T21:06:38.937</Servertime>\r\n    <Traincode>E231
+        </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Howth</Origin>\r\n    <Destination>Bray</Destination>\r\n
+        \   <Origintime>21:15</Origintime>\r\n    <Destinationtime>22:24</Destinationtime>\r\n
+        \   <Status>No Information</Status>\r\n    <Lastlocation />\r\n    <Duein>34</Duein>\r\n
+        \   <Late>0</Late>\r\n    <Exparrival>21:39</Exparrival>\r\n    <Expdepart>21:40</Expdepart>\r\n
+        \   <Scharrival>21:39</Scharrival>\r\n    <Schdepart>21:40</Schdepart>\r\n
+        \   <Direction>Southbound</Direction>\r\n    <Traintype>DART</Traintype>\r\n
+        \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
+        \   <Servertime>2015-10-05T21:06:38.937</Servertime>\r\n    <Traincode>P671
+        </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Maynooth</Origin>\r\n
+        \   <Destination>Dublin Pearse</Destination>\r\n    <Origintime>21:05</Origintime>\r\n
+        \   <Destinationtime>21:49</Destinationtime>\r\n    <Status>No Information</Status>\r\n
+        \   <Lastlocation />\r\n    <Duein>38</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>21:43</Exparrival>\r\n
+        \   <Expdepart>21:44</Expdepart>\r\n    <Scharrival>21:43</Scharrival>\r\n
+        \   <Schdepart>21:44</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
+        \   <Traintype>Train</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.937</Servertime>\r\n
+        \   <Traincode>E131 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Malahide</Origin>\r\n
+        \   <Destination>Greystones</Destination>\r\n    <Origintime>21:30</Origintime>\r\n
+        \   <Destinationtime>22:50</Destinationtime>\r\n    <Status>No Information</Status>\r\n
+        \   <Lastlocation />\r\n    <Duein>49</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>21:54</Exparrival>\r\n
+        \   <Expdepart>21:55</Expdepart>\r\n    <Scharrival>21:54</Scharrival>\r\n
+        \   <Schdepart>21:55</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
         \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.937</Servertime>\r\n
+        \   <Traincode>E232 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Howth</Origin>\r\n    <Destination>Bray</Destination>\r\n
+        \   <Origintime>21:45</Origintime>\r\n    <Destinationtime>22:54</Destinationtime>\r\n
+        \   <Status>No Information</Status>\r\n    <Lastlocation />\r\n    <Duein>64</Duein>\r\n
+        \   <Late>0</Late>\r\n    <Exparrival>22:09</Exparrival>\r\n    <Expdepart>22:10</Expdepart>\r\n
+        \   <Scharrival>22:09</Scharrival>\r\n    <Schdepart>22:10</Schdepart>\r\n
+        \   <Direction>Southbound</Direction>\r\n    <Traintype>DART</Traintype>\r\n
+        \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
+        \   <Servertime>2015-10-05T21:06:38.937</Servertime>\r\n    <Traincode>E710
+        </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Malahide</Origin>\r\n
+        \   <Destination>Dublin Connolly</Destination>\r\n    <Origintime>22:10</Origintime>\r\n
+        \   <Destinationtime>22:35</Destinationtime>\r\n    <Status>No Information</Status>\r\n
+        \   <Lastlocation />\r\n    <Duein>89</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>22:35</Exparrival>\r\n
+        \   <Expdepart>00:00</Expdepart>\r\n    <Scharrival>22:35</Scharrival>\r\n
+        \   <Schdepart>00:00</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
+        \   <Traintype>DART</Traintype>\r\n    <Locationtype>D</Locationtype>\r\n
         \ </objStationData>\r\n</ArrayOfObjStationData>"
     http_version: 
-  recorded_at: Sat, 19 Apr 2014 18:10:57 GMT
-recorded_with: VCR 2.9.0
+  recorded_at: Mon, 05 Oct 2015 20:06:38 GMT
+recorded_with: VCR 2.9.3

--- a/fixtures/vcr_cassettes/station_times.yml
+++ b/fixtures/vcr_cassettes/station_times.yml
@@ -25,76 +25,86 @@ http_interactions:
       Server:
       - ''
       Date:
-      - Sat, 19 Apr 2014 18:10:55 GMT
+      - Mon, 05 Oct 2015 20:06:37 GMT
       Content-Length:
-      - '5161'
+      - '6009'
     body:
       encoding: UTF-8
       string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ArrayOfObjStationData
         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-        xmlns=\"http://api.irishrail.ie/realtime/\">\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.607</Servertime>\r\n
-        \   <Traincode>D819 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Dublin Pearse</Origin>\r\n
-        \   <Destination>Drogheda</Destination>\r\n    <Origintime>19:13</Origintime>\r\n
-        \   <Destinationtime>20:16</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>10</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>19:19</Exparrival>\r\n
-        \   <Expdepart>19:20</Expdepart>\r\n    <Scharrival>19:19</Scharrival>\r\n
-        \   <Schdepart>19:20</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
+        xmlns=\"http://api.irishrail.ie/realtime/\">\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.42</Servertime>\r\n
+        \   <Traincode>E934 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Bray</Origin>\r\n    <Destination>Howth</Destination>\r\n
+        \   <Origintime>20:25</Origintime>\r\n    <Destinationtime>21:33</Destinationtime>\r\n
+        \   <Status>En Route</Status>\r\n    <Lastlocation>Departed Dublin Pearse</Lastlocation>\r\n
+        \   <Duein>5</Duein>\r\n    <Late>2</Late>\r\n    <Exparrival>21:10</Exparrival>\r\n
+        \   <Expdepart>21:11</Expdepart>\r\n    <Scharrival>21:08</Scharrival>\r\n
+        \   <Schdepart>21:09</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
+        \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.42</Servertime>\r\n
+        \   <Traincode>D931 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Dublin Pearse</Origin>\r\n
+        \   <Destination>Maynooth</Destination>\r\n    <Origintime>21:10</Origintime>\r\n
+        \   <Destinationtime>21:56</Destinationtime>\r\n    <Status>No Information</Status>\r\n
+        \   <Lastlocation />\r\n    <Duein>11</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>21:16</Exparrival>\r\n
+        \   <Expdepart>21:17</Expdepart>\r\n    <Scharrival>21:16</Scharrival>\r\n
+        \   <Schdepart>21:17</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
         \   <Traintype>Train</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.607</Servertime>\r\n
-        \   <Traincode>E930 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Greystones</Origin>\r\n
-        \   <Destination>Howth</Destination>\r\n    <Origintime>18:30</Origintime>\r\n
-        \   <Destinationtime>19:52</Destinationtime>\r\n    <Status>En Route</Status>\r\n
-        \   <Lastlocation>Arrived Booterstown</Lastlocation>\r\n    <Duein>17</Duein>\r\n
-        \   <Late>-1</Late>\r\n    <Exparrival>19:26</Exparrival>\r\n    <Expdepart>19:27</Expdepart>\r\n
-        \   <Scharrival>19:27</Scharrival>\r\n    <Schdepart>19:28</Schdepart>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.42</Servertime>\r\n
+        \   <Traincode>E830 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Greystones</Origin>\r\n
+        \   <Destination>Malahide</Destination>\r\n    <Origintime>20:30</Origintime>\r\n
+        \   <Destinationtime>21:50</Destinationtime>\r\n    <Status>En Route</Status>\r\n
+        \   <Lastlocation>Arrived Blackrock</Lastlocation>\r\n    <Duein>19</Duein>\r\n
+        \   <Late>1</Late>\r\n    <Exparrival>21:24</Exparrival>\r\n    <Expdepart>21:25</Expdepart>\r\n
+        \   <Scharrival>21:23</Scharrival>\r\n    <Schdepart>21:24</Schdepart>\r\n
         \   <Direction>Northbound</Direction>\r\n    <Traintype>DART</Traintype>\r\n
         \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
-        \   <Servertime>2014-04-19T19:10:55.607</Servertime>\r\n    <Traincode>E827
+        \   <Servertime>2015-10-05T21:06:38.42</Servertime>\r\n    <Traincode>A913
         </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Bray</Origin>\r\n    <Destination>Malahide</Destination>\r\n
-        \   <Origintime>18:55</Origintime>\r\n    <Destinationtime>20:05</Destinationtime>\r\n
-        \   <Status>En Route</Status>\r\n    <Lastlocation>Arrived Glenageary</Lastlocation>\r\n
-        \   <Duein>30</Duein>\r\n    <Late>1</Late>\r\n    <Exparrival>19:39</Exparrival>\r\n
-        \   <Expdepart>19:40</Expdepart>\r\n    <Scharrival>19:38</Scharrival>\r\n
-        \   <Schdepart>19:39</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Sligo</Origin>\r\n    <Destination>Dublin
+        Connolly</Destination>\r\n    <Origintime>18:00</Origintime>\r\n    <Destinationtime>21:08</Destinationtime>\r\n
+        \   <Status>En Route</Status>\r\n    <Lastlocation>Arrived Drumcondra</Lastlocation>\r\n
+        \   <Duein>6</Duein>\r\n    <Late>4</Late>\r\n    <Exparrival>21:12</Exparrival>\r\n
+        \   <Expdepart>00:00</Expdepart>\r\n    <Scharrival>21:08</Scharrival>\r\n
+        \   <Schdepart>00:00</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
+        \   <Traintype>Train</Traintype>\r\n    <Locationtype>D</Locationtype>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.42</Servertime>\r\n
+        \   <Traincode>E230 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Howth</Origin>\r\n    <Destination>Bray</Destination>\r\n
+        \   <Origintime>20:45</Origintime>\r\n    <Destinationtime>21:57</Destinationtime>\r\n
+        \   <Status>En Route</Status>\r\n    <Lastlocation>Departed Killester</Lastlocation>\r\n
+        \   <Duein>9</Duein>\r\n    <Late>2</Late>\r\n    <Exparrival>21:14</Exparrival>\r\n
+        \   <Expdepart>21:15</Expdepart>\r\n    <Scharrival>21:12</Scharrival>\r\n
+        \   <Schdepart>21:13</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
         \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.607</Servertime>\r\n
-        \   <Traincode>P667 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Maynooth</Origin>\r\n
-        \   <Destination>Dublin Pearse</Destination>\r\n    <Origintime>18:40</Origintime>\r\n
-        \   <Destinationtime>19:23</Destinationtime>\r\n    <Status>En Route</Status>\r\n
-        \   <Lastlocation>Departed Ashtown</Lastlocation>\r\n    <Duein>12</Duein>\r\n
-        \   <Late>3</Late>\r\n    <Exparrival>19:22</Exparrival>\r\n    <Expdepart>19:22</Expdepart>\r\n
-        \   <Scharrival>19:18</Scharrival>\r\n    <Schdepart>19:19</Schdepart>\r\n
-        \   <Direction>Southbound</Direction>\r\n    <Traintype>Train</Traintype>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.42</Servertime>\r\n
+        \   <Traincode>E130 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Malahide</Origin>\r\n
+        \   <Destination>Greystones</Destination>\r\n    <Origintime>21:00</Origintime>\r\n
+        \   <Destinationtime>22:20</Destinationtime>\r\n    <Status>En Route</Status>\r\n
+        \   <Lastlocation>Departed Portmarnock</Lastlocation>\r\n    <Duein>20</Duein>\r\n
+        \   <Late>1</Late>\r\n    <Exparrival>21:25</Exparrival>\r\n    <Expdepart>21:26</Expdepart>\r\n
+        \   <Scharrival>21:24</Scharrival>\r\n    <Schdepart>21:25</Schdepart>\r\n
+        \   <Direction>Southbound</Direction>\r\n    <Traintype>DART</Traintype>\r\n
         \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
-        \   <Servertime>2014-04-19T19:10:55.607</Servertime>\r\n    <Traincode>E126
+        \   <Servertime>2015-10-05T21:06:38.42</Servertime>\r\n    <Traincode>P670
         </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Howth</Origin>\r\n    <Destination>Greystones</Destination>\r\n
-        \   <Origintime>19:00</Origintime>\r\n    <Destinationtime>20:20</Destinationtime>\r\n
-        \   <Status>En Route</Status>\r\n    <Lastlocation>Departed Howth Junction</Lastlocation>\r\n
-        \   <Duein>15</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>19:24</Exparrival>\r\n
-        \   <Expdepart>19:25</Expdepart>\r\n    <Scharrival>19:24</Scharrival>\r\n
-        \   <Schdepart>19:25</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
-        \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.607</Servertime>\r\n
-        \   <Traincode>E227 </Traincode>\r\n    <Stationfullname>Dublin Connolly</Stationfullname>\r\n
-        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Malahide</Origin>\r\n
-        \   <Destination>Bray</Destination>\r\n    <Origintime>19:15</Origintime>\r\n
-        \   <Destinationtime>20:24</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>30</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>19:39</Exparrival>\r\n
-        \   <Expdepart>19:40</Expdepart>\r\n    <Scharrival>19:39</Scharrival>\r\n
-        \   <Schdepart>19:40</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
-        \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n</ArrayOfObjStationData>"
+        \   <Stationcode>CNLLY</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Maynooth</Origin>\r\n
+        \   <Destination>Dublin Pearse</Destination>\r\n    <Origintime>20:47</Origintime>\r\n
+        \   <Destinationtime>21:34</Destinationtime>\r\n    <Status>En Route</Status>\r\n
+        \   <Lastlocation>Arrived Clonsilla</Lastlocation>\r\n    <Duein>28</Duein>\r\n
+        \   <Late>5</Late>\r\n    <Exparrival>21:33</Exparrival>\r\n    <Expdepart>21:34</Expdepart>\r\n
+        \   <Scharrival>21:28</Scharrival>\r\n    <Schdepart>21:29</Schdepart>\r\n
+        \   <Direction>Southbound</Direction>\r\n    <Traintype>Train</Traintype>\r\n
+        \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n</ArrayOfObjStationData>"
     http_version: 
-  recorded_at: Sat, 19 Apr 2014 18:10:57 GMT
-recorded_with: VCR 2.9.0
+  recorded_at: Mon, 05 Oct 2015 20:06:37 GMT
+recorded_with: VCR 2.9.3

--- a/fixtures/vcr_cassettes/stations.yml
+++ b/fixtures/vcr_cassettes/stations.yml
@@ -25,7 +25,7 @@ http_interactions:
       Server:
       - ''
       Date:
-      - Sat, 19 Apr 2014 18:10:56 GMT
+      - Mon, 05 Oct 2015 20:06:38 GMT
       Content-Length:
       - '42965'
     body:
@@ -516,5 +516,5 @@ http_interactions:
         \   <StationLongitude>-8.29956</StationLongitude>\r\n    <StationCode>COBH
         </StationCode>\r\n    <StationId>66</StationId>\r\n  </objStation>\r\n</ArrayOfObjStation>"
     http_version: 
-  recorded_at: Sat, 19 Apr 2014 18:10:58 GMT
-recorded_with: VCR 2.9.0
+  recorded_at: Mon, 05 Oct 2015 20:06:39 GMT
+recorded_with: VCR 2.9.3

--- a/fixtures/vcr_cassettes/train_movements.yml
+++ b/fixtures/vcr_cassettes/train_movements.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.irishrail.ie/realtime/realtime.asmx/getTrainMovementsXML?TrainDate=19/04/2014&TrainId=D288
+    uri: http://api.irishrail.ie/realtime/realtime.asmx/getTrainMovementsXML?TrainDate=19/04/2014&TrainId=D258
     body:
       encoding: US-ASCII
       string: ''
@@ -25,54 +25,70 @@ http_interactions:
       Server:
       - ''
       Date:
-      - Sat, 19 Apr 2014 18:10:56 GMT
+      - Mon, 05 Oct 2015 20:06:38 GMT
       Content-Length:
-      - '3678'
+      - '5013'
     body:
       encoding: UTF-8
       string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ArrayOfObjTrainMovements
         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
         xmlns=\"http://api.irishrail.ie/realtime/\">\r\n  <objTrainMovements>\r\n
-        \   <TrainCode>D288 </TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
+        \   <TrainCode>D258 </TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
         \   <LocationCode>CORK</LocationCode>\r\n    <LocationFullName>Cork</LocationFullName>\r\n
         \   <LocationOrder>1</LocationOrder>\r\n    <LocationType>O</LocationType>\r\n
-        \   <TrainOrigin>Cork</TrainOrigin>\r\n    <TrainDestination>Midleton</TrainDestination>\r\n
-        \   <ScheduledArrival>00:00:00</ScheduledArrival>\r\n    <ScheduledDeparture>19:15:00</ScheduledDeparture>\r\n
-        \   <ExpectedArrival>00:00:00</ExpectedArrival>\r\n    <ExpectedDeparture>19:15:00</ExpectedDeparture>\r\n
+        \   <TrainOrigin>Cork</TrainOrigin>\r\n    <TrainDestination>Cobh</TrainDestination>\r\n
+        \   <ScheduledArrival>00:00:00</ScheduledArrival>\r\n    <ScheduledDeparture>21:00:00</ScheduledDeparture>\r\n
+        \   <ExpectedArrival>00:00:00</ExpectedArrival>\r\n    <ExpectedDeparture>21:00:00</ExpectedDeparture>\r\n
         \   <Arrival />\r\n    <Departure />\r\n    <AutoArrival />\r\n    <AutoDepart
-        />\r\n    <StopType>C</StopType>\r\n  </objTrainMovements>\r\n  <objTrainMovements>\r\n
-        \   <TrainCode>D288 </TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
+        />\r\n    <StopType>-</StopType>\r\n  </objTrainMovements>\r\n  <objTrainMovements>\r\n
+        \   <TrainCode>D258 </TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
         \   <LocationCode>LSLND</LocationCode>\r\n    <LocationFullName>LittleIsland</LocationFullName>\r\n
         \   <LocationOrder>2</LocationOrder>\r\n    <LocationType>S</LocationType>\r\n
-        \   <TrainOrigin>Cork</TrainOrigin>\r\n    <TrainDestination>Midleton</TrainDestination>\r\n
-        \   <ScheduledArrival>19:21:30</ScheduledArrival>\r\n    <ScheduledDeparture>19:22:00</ScheduledDeparture>\r\n
-        \   <ExpectedArrival>19:21:30</ExpectedArrival>\r\n    <ExpectedDeparture>19:22:00</ExpectedDeparture>\r\n
+        \   <TrainOrigin>Cork</TrainOrigin>\r\n    <TrainDestination>Cobh</TrainDestination>\r\n
+        \   <ScheduledArrival>21:06:30</ScheduledArrival>\r\n    <ScheduledDeparture>21:07:00</ScheduledDeparture>\r\n
+        \   <ExpectedArrival>21:06:30</ExpectedArrival>\r\n    <ExpectedDeparture>21:07:00</ExpectedDeparture>\r\n
         \   <Arrival />\r\n    <Departure />\r\n    <AutoArrival />\r\n    <AutoDepart
-        />\r\n    <StopType>N</StopType>\r\n  </objTrainMovements>\r\n  <objTrainMovements>\r\n
-        \   <TrainCode>D288 </TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
+        />\r\n    <StopType>-</StopType>\r\n  </objTrainMovements>\r\n  <objTrainMovements>\r\n
+        \   <TrainCode>D258 </TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
         \   <LocationCode>GHANE</LocationCode>\r\n    <LocationFullName>Glounthaune</LocationFullName>\r\n
         \   <LocationOrder>3</LocationOrder>\r\n    <LocationType>S</LocationType>\r\n
-        \   <TrainOrigin>Cork</TrainOrigin>\r\n    <TrainDestination>Midleton</TrainDestination>\r\n
-        \   <ScheduledArrival>19:24:30</ScheduledArrival>\r\n    <ScheduledDeparture>19:25:00</ScheduledDeparture>\r\n
-        \   <ExpectedArrival>19:24:30</ExpectedArrival>\r\n    <ExpectedDeparture>19:25:00</ExpectedDeparture>\r\n
+        \   <TrainOrigin>Cork</TrainOrigin>\r\n    <TrainDestination>Cobh</TrainDestination>\r\n
+        \   <ScheduledArrival>21:09:30</ScheduledArrival>\r\n    <ScheduledDeparture>21:10:00</ScheduledDeparture>\r\n
+        \   <ExpectedArrival>21:09:30</ExpectedArrival>\r\n    <ExpectedDeparture>21:10:00</ExpectedDeparture>\r\n
         \   <Arrival />\r\n    <Departure />\r\n    <AutoArrival />\r\n    <AutoDepart
         />\r\n    <StopType>-</StopType>\r\n  </objTrainMovements>\r\n  <objTrainMovements>\r\n
-        \   <TrainCode>D288 </TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
-        \   <LocationCode>CGTWL</LocationCode>\r\n    <LocationFullName>Carrigtwohill</LocationFullName>\r\n
+        \   <TrainCode>D258 </TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
+        \   <LocationCode>FOTA</LocationCode>\r\n    <LocationFullName>Fota</LocationFullName>\r\n
         \   <LocationOrder>4</LocationOrder>\r\n    <LocationType>S</LocationType>\r\n
-        \   <TrainOrigin>Cork</TrainOrigin>\r\n    <TrainDestination>Midleton</TrainDestination>\r\n
-        \   <ScheduledArrival>19:30:00</ScheduledArrival>\r\n    <ScheduledDeparture>19:30:30</ScheduledDeparture>\r\n
-        \   <ExpectedArrival>19:30:00</ExpectedArrival>\r\n    <ExpectedDeparture>19:30:30</ExpectedDeparture>\r\n
+        \   <TrainOrigin>Cork</TrainOrigin>\r\n    <TrainDestination>Cobh</TrainDestination>\r\n
+        \   <ScheduledArrival>21:13:00</ScheduledArrival>\r\n    <ScheduledDeparture>21:13:30</ScheduledDeparture>\r\n
+        \   <ExpectedArrival>21:13:00</ExpectedArrival>\r\n    <ExpectedDeparture>21:13:30</ExpectedDeparture>\r\n
         \   <Arrival />\r\n    <Departure />\r\n    <AutoArrival />\r\n    <AutoDepart
         />\r\n    <StopType>-</StopType>\r\n  </objTrainMovements>\r\n  <objTrainMovements>\r\n
-        \   <TrainCode>D288 </TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
-        \   <LocationCode>MDLTN</LocationCode>\r\n    <LocationFullName>Midleton</LocationFullName>\r\n
-        \   <LocationOrder>5</LocationOrder>\r\n    <LocationType>D</LocationType>\r\n
-        \   <TrainOrigin>Cork</TrainOrigin>\r\n    <TrainDestination>Midleton</TrainDestination>\r\n
-        \   <ScheduledArrival>19:38:00</ScheduledArrival>\r\n    <ScheduledDeparture>00:00:00</ScheduledDeparture>\r\n
-        \   <ExpectedArrival>19:38:00</ExpectedArrival>\r\n    <ExpectedDeparture>00:00:00</ExpectedDeparture>\r\n
+        \   <TrainCode>D258 </TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
+        \   <LocationCode>CGLOE</LocationCode>\r\n    <LocationFullName>Carrigaloe</LocationFullName>\r\n
+        \   <LocationOrder>5</LocationOrder>\r\n    <LocationType>S</LocationType>\r\n
+        \   <TrainOrigin>Cork</TrainOrigin>\r\n    <TrainDestination>Cobh</TrainDestination>\r\n
+        \   <ScheduledArrival>21:17:00</ScheduledArrival>\r\n    <ScheduledDeparture>21:17:30</ScheduledDeparture>\r\n
+        \   <ExpectedArrival>21:17:00</ExpectedArrival>\r\n    <ExpectedDeparture>21:17:30</ExpectedDeparture>\r\n
         \   <Arrival />\r\n    <Departure />\r\n    <AutoArrival />\r\n    <AutoDepart
-        />\r\n    <StopType>-</StopType>\r\n  </objTrainMovements>\r\n</ArrayOfObjTrainMovements>"
+        />\r\n    <StopType>-</StopType>\r\n  </objTrainMovements>\r\n  <objTrainMovements>\r\n
+        \   <TrainCode>D258 </TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
+        \   <LocationCode>RBROK</LocationCode>\r\n    <LocationFullName>Rushbrooke</LocationFullName>\r\n
+        \   <LocationOrder>6</LocationOrder>\r\n    <LocationType>S</LocationType>\r\n
+        \   <TrainOrigin>Cork</TrainOrigin>\r\n    <TrainDestination>Cobh</TrainDestination>\r\n
+        \   <ScheduledArrival>21:20:30</ScheduledArrival>\r\n    <ScheduledDeparture>21:21:00</ScheduledDeparture>\r\n
+        \   <ExpectedArrival>21:20:30</ExpectedArrival>\r\n    <ExpectedDeparture>21:21:00</ExpectedDeparture>\r\n
+        \   <Arrival />\r\n    <Departure />\r\n    <AutoArrival />\r\n    <AutoDepart
+        />\r\n    <StopType>-</StopType>\r\n  </objTrainMovements>\r\n  <objTrainMovements>\r\n
+        \   <TrainCode>D258 </TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
+        \   <LocationCode>COBH</LocationCode>\r\n    <LocationFullName>Cobh</LocationFullName>\r\n
+        \   <LocationOrder>7</LocationOrder>\r\n    <LocationType>D</LocationType>\r\n
+        \   <TrainOrigin>Cork</TrainOrigin>\r\n    <TrainDestination>Cobh</TrainDestination>\r\n
+        \   <ScheduledArrival>21:24:00</ScheduledArrival>\r\n    <ScheduledDeparture>00:00:00</ScheduledDeparture>\r\n
+        \   <ExpectedArrival>21:24:00</ExpectedArrival>\r\n    <ExpectedDeparture>00:00:00</ExpectedDeparture>\r\n
+        \   <Arrival />\r\n    <Departure />\r\n    <AutoArrival />\r\n    <AutoDepart
+        />\r\n    <StopType>C</StopType>\r\n  </objTrainMovements>\r\n</ArrayOfObjTrainMovements>"
     http_version: 
-  recorded_at: Sat, 19 Apr 2014 18:10:58 GMT
-recorded_with: VCR 2.9.0
+  recorded_at: Mon, 05 Oct 2015 20:06:38 GMT
+recorded_with: VCR 2.9.3

--- a/fixtures/vcr_cassettes/trains.yml
+++ b/fixtures/vcr_cassettes/trains.yml
@@ -25,302 +25,257 @@ http_interactions:
       Server:
       - ''
       Date:
-      - Sat, 19 Apr 2014 18:10:56 GMT
+      - Mon, 05 Oct 2015 20:06:38 GMT
       Content-Length:
-      - '23417'
+      - '19740'
     body:
       encoding: UTF-8
       string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ArrayOfObjTrainPositions
         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
         xmlns=\"http://api.irishrail.ie/realtime/\">\r\n  <objTrainPositions>\r\n
         \   <TrainStatus>N</TrainStatus>\r\n    <TrainLatitude>51.9018</TrainLatitude>\r\n
-        \   <TrainLongitude>-8.4582</TrainLongitude>\r\n    <TrainCode>D288</TrainCode>\r\n
-        \   <TrainDate>19 Apr 2014</TrainDate>\r\n    <PublicMessage>D288\\nCork to
-        Midleton\\nExpected Departure 19:15</PublicMessage>\r\n    <Direction>To Midleton</Direction>\r\n
+        \   <TrainLongitude>-8.4582</TrainLongitude>\r\n    <TrainCode>D258</TrainCode>\r\n
+        \   <TrainDate>05 Oct 2015</TrainDate>\r\n    <PublicMessage>D258\\nCork to
+        Cobh\\nExpected Departure 21:00</PublicMessage>\r\n    <Direction>To Cobh</Direction>\r\n
         \ </objTrainPositions>\r\n  <objTrainPositions>\r\n    <TrainStatus>N</TrainStatus>\r\n
-        \   <TrainLatitude>52.271</TrainLatitude>\r\n    <TrainLongitude>-9.69846</TrainLongitude>\r\n
-        \   <TrainCode>A315</TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
-        \   <PublicMessage>A315\\nTralee to Cork\\nExpected Departure 19:05</PublicMessage>\r\n
-        \   <Direction>To Cork</Direction>\r\n  </objTrainPositions>\r\n  <objTrainPositions>\r\n
+        \   <TrainLatitude>51.9018</TrainLatitude>\r\n    <TrainLongitude>-8.4582</TrainLongitude>\r\n
+        \   <TrainCode>D290</TrainCode>\r\n    <TrainDate>05 Oct 2015</TrainDate>\r\n
+        \   <PublicMessage>D290\\nCork to Midleton\\nExpected Departure 21:15</PublicMessage>\r\n
+        \   <Direction>To Midleton</Direction>\r\n  </objTrainPositions>\r\n  <objTrainPositions>\r\n
         \   <TrainStatus>N</TrainStatus>\r\n    <TrainLatitude>52.8386</TrainLatitude>\r\n
-        \   <TrainLongitude>-8.97491</TrainLongitude>\r\n    <TrainCode>A788</TrainCode>\r\n
-        \   <TrainDate>19 Apr 2014</TrainDate>\r\n    <PublicMessage>A788\\nEnnis
-        to Galway\\nExpected Departure 19:05</PublicMessage>\r\n    <Direction>To
-        Galway</Direction>\r\n  </objTrainPositions>\r\n  <objTrainPositions>\r\n
-        \   <TrainStatus>N</TrainStatus>\r\n    <TrainLatitude>52.8386</TrainLatitude>\r\n
-        \   <TrainLongitude>-8.97491</TrainLongitude>\r\n    <TrainCode>B487</TrainCode>\r\n
-        \   <TrainDate>19 Apr 2014</TrainDate>\r\n    <PublicMessage>B487\\nEnnis
-        to Limerick\\nExpected Departure 19:05</PublicMessage>\r\n    <Direction>To
+        \   <TrainLongitude>-8.97491</TrainLongitude>\r\n    <TrainCode>A479</TrainCode>\r\n
+        \   <TrainDate>05 Oct 2015</TrainDate>\r\n    <PublicMessage>A479\\nEnnis
+        to Limerick\\nExpected Departure 21:10</PublicMessage>\r\n    <Direction>To
         Limerick</Direction>\r\n  </objTrainPositions>\r\n  <objTrainPositions>\r\n
-        \   <TrainStatus>N</TrainStatus>\r\n    <TrainLatitude>53.2043</TrainLatitude>\r\n
-        \   <TrainLongitude>-6.10046</TrainLongitude>\r\n    <TrainCode>E931</TrainCode>\r\n
-        \   <TrainDate>19 Apr 2014</TrainDate>\r\n    <PublicMessage>E931\\nBray to
-        Howth\\nExpected Departure 19:10</PublicMessage>\r\n    <Direction>Northbound</Direction>\r\n
+        \   <TrainStatus>N</TrainStatus>\r\n    <TrainLatitude>53.3433</TrainLatitude>\r\n
+        \   <TrainLongitude>-6.24829</TrainLongitude>\r\n    <TrainCode>D931</TrainCode>\r\n
+        \   <TrainDate>05 Oct 2015</TrainDate>\r\n    <PublicMessage>D931\\nDublin
+        Pearse to Maynooth\\nExpected Departure 21:10</PublicMessage>\r\n    <Direction>Northbound</Direction>\r\n
         \ </objTrainPositions>\r\n  <objTrainPositions>\r\n    <TrainStatus>N</TrainStatus>\r\n
-        \   <TrainLatitude>53.3433</TrainLatitude>\r\n    <TrainLongitude>-6.24829</TrainLongitude>\r\n
-        \   <TrainCode>D819</TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
-        \   <PublicMessage>D819\\nDublin Pearse to Drogheda\\nExpected Departure 19:13</PublicMessage>\r\n
-        \   <Direction>Northbound</Direction>\r\n  </objTrainPositions>\r\n  <objTrainPositions>\r\n
-        \   <TrainStatus>N</TrainStatus>\r\n    <TrainLatitude>53.3831</TrainLatitude>\r\n
-        \   <TrainLongitude>-6.4242</TrainLongitude>\r\n    <TrainCode>D336</TrainCode>\r\n
-        \   <TrainDate>19 Apr 2014</TrainDate>\r\n    <PublicMessage>D336\\nClonsilla
-        to M3 Parkway\\nExpected Departure 19:15</PublicMessage>\r\n    <Direction>Northbound</Direction>\r\n
+        \   <TrainLatitude>53.3464</TrainLatitude>\r\n    <TrainLongitude>-6.29461</TrainLongitude>\r\n
+        \   <TrainCode>A230</TrainCode>\r\n    <TrainDate>05 Oct 2015</TrainDate>\r\n
+        \   <PublicMessage>A230\\nDublin Heuston to Cork\\nExpected Departure 21:00</PublicMessage>\r\n
+        \   <Direction>To Cork</Direction>\r\n  </objTrainPositions>\r\n  <objTrainPositions>\r\n
+        \   <TrainStatus>N</TrainStatus>\r\n    <TrainLatitude>53.378</TrainLatitude>\r\n
+        \   <TrainLongitude>-6.58993</TrainLongitude>\r\n    <TrainCode>P671</TrainCode>\r\n
+        \   <TrainDate>05 Oct 2015</TrainDate>\r\n    <PublicMessage>P671\\nMaynooth
+        to Dublin Pearse\\nExpected Departure 21:05</PublicMessage>\r\n    <Direction>Southbound</Direction>\r\n
         \ </objTrainPositions>\r\n  <objTrainPositions>\r\n    <TrainStatus>N</TrainStatus>\r\n
-        \   <TrainLatitude>53.4509</TrainLatitude>\r\n    <TrainLongitude>-6.15649</TrainLongitude>\r\n
-        \   <TrainCode>E227</TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
-        \   <PublicMessage>E227\\nMalahide to Bray\\nExpected Departure 19:15</PublicMessage>\r\n
+        \   <TrainLatitude>53.3891</TrainLatitude>\r\n    <TrainLongitude>-6.07401</TrainLongitude>\r\n
+        \   <TrainCode>E231</TrainCode>\r\n    <TrainDate>05 Oct 2015</TrainDate>\r\n
+        \   <PublicMessage>E231\\nHowth to Bray\\nExpected Departure 21:15</PublicMessage>\r\n
+        \   <Direction>Southbound</Direction>\r\n  </objTrainPositions>\r\n  <objTrainPositions>\r\n
+        \   <TrainStatus>N</TrainStatus>\r\n    <TrainLatitude>54.6123</TrainLatitude>\r\n
+        \   <TrainLongitude>-5.91744</TrainLongitude>\r\n    <TrainCode>A143</TrainCode>\r\n
+        \   <TrainDate>05 Oct 2015</TrainDate>\r\n    <PublicMessage>A143\\nBelfast
+        Central to Dublin Connolly\\nExpected Departure 21:15</PublicMessage>\r\n
         \   <Direction>Southbound</Direction>\r\n  </objTrainPositions>\r\n  <objTrainPositions>\r\n
         \   <TrainStatus>R</TrainStatus>\r\n    <TrainLatitude>0</TrainLatitude>\r\n
-        \   <TrainLongitude>0</TrainLongitude>\r\n    <TrainCode>A227</TrainCode>\r\n
-        \   <TrainDate>19 Apr 2014</TrainDate>\r\n    <PublicMessage>A227\\n18:20
-        - Cork to Dublin Heuston (-5 mins late)\\nArrived LJ895 next stop Limerick
+        \   <TrainLongitude>0</TrainLongitude>\r\n    <TrainCode>A226</TrainCode>\r\n
+        \   <TrainDate>05 Oct 2015</TrainDate>\r\n    <PublicMessage>A226\\n19:00
+        - Dublin Heuston to Cork (9 mins late)\\nDeparted LJ896 next stop Charleville</PublicMessage>\r\n
+        \   <Direction>To Cork</Direction>\r\n  </objTrainPositions>\r\n  <objTrainPositions>\r\n
+        \   <TrainStatus>R</TrainStatus>\r\n    <TrainLatitude>0</TrainLatitude>\r\n
+        \   <TrainLongitude>0</TrainLongitude>\r\n    <TrainCode>A229</TrainCode>\r\n
+        \   <TrainDate>05 Oct 2015</TrainDate>\r\n    <PublicMessage>A229\\n19:20
+        - Cork to Dublin Heuston (-1 mins late)\\nDeparted PL101 next stop Portlaoise</PublicMessage>\r\n
+        \   <Direction>To Dublin Heuston</Direction>\r\n  </objTrainPositions>\r\n
+        \ <objTrainPositions>\r\n    <TrainStatus>R</TrainStatus>\r\n    <TrainLatitude>0</TrainLatitude>\r\n
+        \   <TrainLongitude>0</TrainLongitude>\r\n    <TrainCode>A231</TrainCode>\r\n
+        \   <TrainDate>05 Oct 2015</TrainDate>\r\n    <PublicMessage>A231\\n20:20
+        - Cork to Dublin Heuston (-3 mins late)\\nArrived LJ895 next stop Limerick
         Junction</PublicMessage>\r\n    <Direction>To Dublin Heuston</Direction>\r\n
         \ </objTrainPositions>\r\n  <objTrainPositions>\r\n    <TrainStatus>R</TrainStatus>\r\n
         \   <TrainLatitude>0</TrainLatitude>\r\n    <TrainLongitude>0</TrainLongitude>\r\n
-        \   <TrainCode>A410</TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
-        \   <PublicMessage>A410\\n17:25 - Dublin Heuston to Limerick (2 mins late)\\nArrived
-        LJ458 next stop Limerick</PublicMessage>\r\n    <Direction>To Limerick</Direction>\r\n
+        \   <TrainCode>A315</TrainCode>\r\n    <TrainDate>05 Oct 2015</TrainDate>\r\n
+        \   <PublicMessage>A315\\n19:39 - Killarney to Cork (4 mins late)\\nArrived
+        Killarney Junction next stop Cork</PublicMessage>\r\n    <Direction>To Cork</Direction>\r\n
         \ </objTrainPositions>\r\n  <objTrainPositions>\r\n    <TrainStatus>R</TrainStatus>\r\n
         \   <TrainLatitude>0</TrainLatitude>\r\n    <TrainLongitude>0</TrainLongitude>\r\n
-        \   <TrainCode>A714</TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
-        \   <PublicMessage>A714\\n17:30 - Dublin Heuston to Galway (2 mins late)\\nDeparted
-        Athlone Midland Yard next stop Ballinasloe</PublicMessage>\r\n    <Direction>To
-        Galway</Direction>\r\n  </objTrainPositions>\r\n  <objTrainPositions>\r\n
-        \   <TrainStatus>R</TrainStatus>\r\n    <TrainLatitude>51.939</TrainLatitude>\r\n
-        \   <TrainLongitude>-8.50861</TrainLongitude>\r\n    <TrainCode>A313</TrainCode>\r\n
-        \   <TrainDate>19 Apr 2014</TrainDate>\r\n    <PublicMessage>A313\\n17:05
-        - Tralee to Cork (0 mins late)\\nDeparted Rathpeacon next stop Cork</PublicMessage>\r\n
-        \   <Direction>To Cork</Direction>\r\n  </objTrainPositions>\r\n  <objTrainPositions>\r\n
-        \   <TrainStatus>R</TrainStatus>\r\n    <TrainLatitude>52.2531</TrainLatitude>\r\n
-        \   <TrainLongitude>-6.33493</TrainLongitude>\r\n    <TrainCode>A613</TrainCode>\r\n
-        \   <TrainDate>19 Apr 2014</TrainDate>\r\n    <PublicMessage>A613\\n17:55
-        - Rosslare Europort to Dublin Connolly (0 mins late)\\nDeparted Rosslare Europort
-        next stop Rosslare Strand</PublicMessage>\r\n    <Direction>Northbound</Direction>\r\n
+        \   <TrainCode>A808</TrainCode>\r\n    <TrainDate>05 Oct 2015</TrainDate>\r\n
+        \   <PublicMessage>A808\\n18:15 - Dublin Heuston to Westport (9 mins late)\\nDeparted
+        Athlone Midland Yard next stop Roscommon</PublicMessage>\r\n    <Direction>To
+        Westport</Direction>\r\n  </objTrainPositions>\r\n  <objTrainPositions>\r\n
+        \   <TrainStatus>R</TrainStatus>\r\n    <TrainLatitude>0</TrainLatitude>\r\n
+        \   <TrainLongitude>0</TrainLongitude>\r\n    <TrainCode>D219</TrainCode>\r\n
+        \   <TrainDate>05 Oct 2015</TrainDate>\r\n    <PublicMessage>D219\\n21:05
+        - Dublin Heuston to Portlaoise (-7 mins late)\\nArrived Inchicore Advance
+        Starter next stop Cherry Orchard</PublicMessage>\r\n    <Direction>To Portlaoise</Direction>\r\n
         \ </objTrainPositions>\r\n  <objTrainPositions>\r\n    <TrainStatus>R</TrainStatus>\r\n
-        \   <TrainLatitude>52.3468</TrainLatitude>\r\n    <TrainLongitude>-8.65362</TrainLongitude>\r\n
-        \   <TrainCode>A222</TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
-        \   <PublicMessage>A222\\n17:00 - Dublin Heuston to Cork (13 mins late)\\nDeparted
-        Charleville next stop Mallow</PublicMessage>\r\n    <Direction>To Cork</Direction>\r\n
+        \   <TrainLatitude>51.939</TrainLatitude>\r\n    <TrainLongitude>-8.50861</TrainLongitude>\r\n
+        \   <TrainCode>A314</TrainCode>\r\n    <TrainDate>05 Oct 2015</TrainDate>\r\n
+        \   <PublicMessage>A314\\n20:55 - Cork to Tralee (0 mins late)\\nDeparted
+        Rathpeacon next stop Mallow</PublicMessage>\r\n    <Direction>To Tralee</Direction>\r\n
         \ </objTrainPositions>\r\n  <objTrainPositions>\r\n    <TrainStatus>R</TrainStatus>\r\n
-        \   <TrainLatitude>52.3468</TrainLatitude>\r\n    <TrainLongitude>-8.65362</TrainLongitude>\r\n
-        \   <TrainCode>A312</TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
-        \   <PublicMessage>A312\\n17:05 - Dublin Heuston to Tralee (11 mins late)\\nArrived
-        Charleville next stop Mallow</PublicMessage>\r\n    <Direction>To Tralee</Direction>\r\n
+        \   <TrainLatitude>52.1396</TrainLatitude>\r\n    <TrainLongitude>-8.65521</TrainLongitude>\r\n
+        \   <TrainCode>A312</TrainCode>\r\n    <TrainDate>05 Oct 2015</TrainDate>\r\n
+        \   <PublicMessage>A312\\n17:05 - Dublin Heuston to Tralee (1 mins late)\\nDeparted
+        Mallow next stop Banteer</PublicMessage>\r\n    <Direction>To Tralee</Direction>\r\n
         \ </objTrainPositions>\r\n  <objTrainPositions>\r\n    <TrainStatus>R</TrainStatus>\r\n
         \   <TrainLatitude>52.5828</TrainLatitude>\r\n    <TrainLongitude>-8.38682</TrainLongitude>\r\n
-        \   <TrainCode>A445</TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
-        \   <PublicMessage>A445\\n18:50 - Limerick to Limerick Junction (5 mins late)\\nDeparted
+        \   <TrainCode>A449</TrainCode>\r\n    <TrainDate>05 Oct 2015</TrainDate>\r\n
+        \   <PublicMessage>A449\\n20:45 - Limerick to Limerick Junction (4 mins late)\\nDeparted
         Drumkeen next stop Limerick Junction</PublicMessage>\r\n    <Direction>To
         Limerick Junction</Direction>\r\n  </objTrainPositions>\r\n  <objTrainPositions>\r\n
-        \   <TrainStatus>R</TrainStatus>\r\n    <TrainLatitude>52.6404</TrainLatitude>\r\n
-        \   <TrainLongitude>-8.52719</TrainLongitude>\r\n    <TrainCode>A446</TrainCode>\r\n
-        \   <TrainDate>19 Apr 2014</TrainDate>\r\n    <PublicMessage>A446\\n18:34
-        - Limerick Junction to Limerick (8 mins late)\\nDeparted Killonan next stop
+        \   <TrainStatus>R</TrainStatus>\r\n    <TrainLatitude>52.5828</TrainLatitude>\r\n
+        \   <TrainLongitude>-8.38682</TrainLongitude>\r\n    <TrainCode>A450</TrainCode>\r\n
+        \   <TrainDate>05 Oct 2015</TrainDate>\r\n    <PublicMessage>A450\\n20:45
+        - Limerick Junction to Limerick (1 mins late)\\nDeparted Drumkeen next stop
         Limerick</PublicMessage>\r\n    <Direction>To Limerick</Direction>\r\n  </objTrainPositions>\r\n
-        \ <objTrainPositions>\r\n    <TrainStatus>R</TrainStatus>\r\n    <TrainLatitude>52.655</TrainLatitude>\r\n
-        \   <TrainLongitude>-7.24498</TrainLongitude>\r\n    <TrainCode>A517</TrainCode>\r\n
-        \   <TrainDate>19 Apr 2014</TrainDate>\r\n    <PublicMessage>A517\\n18:25
-        - Waterford to Dublin Heuston (9 mins late)\\nArrived Kilkenny next stop Muine
-        Bheag</PublicMessage>\r\n    <Direction>To Dublin Heuston</Direction>\r\n
+        \ <objTrainPositions>\r\n    <TrainStatus>R</TrainStatus>\r\n    <TrainLatitude>52.6404</TrainLatitude>\r\n
+        \   <TrainLongitude>-8.52719</TrainLongitude>\r\n    <TrainCode>A464</TrainCode>\r\n
+        \   <TrainDate>05 Oct 2015</TrainDate>\r\n    <PublicMessage>A464\\n19:00
+        - Ballybrophy to Limerick (6 mins late)\\nDeparted Killonan next stop Limerick</PublicMessage>\r\n
+        \   <Direction>To Limerick</Direction>\r\n  </objTrainPositions>\r\n  <objTrainPositions>\r\n
+        \   <TrainStatus>R</TrainStatus>\r\n    <TrainLatitude>52.6404</TrainLatitude>\r\n
+        \   <TrainLongitude>-8.52719</TrainLongitude>\r\n    <TrainCode>A478</TrainCode>\r\n
+        \   <TrainDate>05 Oct 2015</TrainDate>\r\n    <PublicMessage>A478\\n19:38
+        - Limerick Junction to Ennis (6 mins late)\\nDeparted Killonan next stop Limerick</PublicMessage>\r\n
+        \   <Direction>To Ennis</Direction>\r\n  </objTrainPositions>\r\n  <objTrainPositions>\r\n
+        \   <TrainStatus>R</TrainStatus>\r\n    <TrainLatitude>53.1442</TrainLatitude>\r\n
+        \   <TrainLongitude>-6.06085</TrainLongitude>\r\n    <TrainCode>A612</TrainCode>\r\n
+        \   <TrainDate>05 Oct 2015</TrainDate>\r\n    <PublicMessage>A612\\n18:38
+        - Dublin Connolly to Rosslare Europort (0 mins late)\\nDeparted Greystones
+        next stop Kilcoole</PublicMessage>\r\n    <Direction>Southbound</Direction>\r\n
         \ </objTrainPositions>\r\n  <objTrainPositions>\r\n    <TrainStatus>R</TrainStatus>\r\n
-        \   <TrainLatitude>52.8999</TrainLatitude>\r\n    <TrainLongitude>-7.60259</TrainLongitude>\r\n
-        \   <TrainCode>A224</TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
-        \   <PublicMessage>A224\\n18:00 - Dublin Heuston to Cork (10 mins late)\\nDeparted
-        Ballybrophy next stop Thurles</PublicMessage>\r\n    <Direction>To Cork</Direction>\r\n
+        \   <TrainLatitude>53.1442</TrainLatitude>\r\n    <TrainLongitude>-6.06085</TrainLongitude>\r\n
+        \   <TrainCode>E831</TrainCode>\r\n    <TrainDate>05 Oct 2015</TrainDate>\r\n
+        \   <PublicMessage>E831\\n21:00 - Greystones to Malahide (0 mins late)\\nDeparted
+        Greystones next stop Bray</PublicMessage>\r\n    <Direction>Northbound</Direction>\r\n
         \ </objTrainPositions>\r\n  <objTrainPositions>\r\n    <TrainStatus>R</TrainStatus>\r\n
-        \   <TrainLatitude>52.8999</TrainLatitude>\r\n    <TrainLongitude>-7.60259</TrainLongitude>\r\n
-        \   <TrainCode>A464</TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
-        \   <PublicMessage>A464\\n19:00 - Ballybrophy to Limerick (0 mins late)\\nDeparted
-        Ballybrophy next stop Roscrea</PublicMessage>\r\n    <Direction>To Limerick</Direction>\r\n
-        \ </objTrainPositions>\r\n  <objTrainPositions>\r\n    <TrainStatus>R</TrainStatus>\r\n
-        \   <TrainLatitude>52.992</TrainLatitude>\r\n    <TrainLongitude>-6.9762</TrainLongitude>\r\n
-        \   <TrainCode>A510</TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
-        \   <PublicMessage>A510\\n16:40 - Dublin Heuston to Waterford (2 mins late)\\nDeparted
-        Athy next stop Carlow</PublicMessage>\r\n    <Direction>To Waterford</Direction>\r\n
-        \ </objTrainPositions>\r\n  <objTrainPositions>\r\n    <TrainStatus>R</TrainStatus>\r\n
-        \   <TrainLatitude>52.992</TrainLatitude>\r\n    <TrainLongitude>-6.9762</TrainLongitude>\r\n
-        \   <TrainCode>A512</TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
-        \   <PublicMessage>A512\\n17:35 - Dublin Heuston to Waterford (0 mins late)\\nDeparted
-        Athy next stop Carlow</PublicMessage>\r\n    <Direction>To Waterford</Direction>\r\n
-        \ </objTrainPositions>\r\n  <objTrainPositions>\r\n    <TrainStatus>R</TrainStatus>\r\n
-        \   <TrainLatitude>53.0371</TrainLatitude>\r\n    <TrainLongitude>-7.30086</TrainLongitude>\r\n
-        \   <TrainCode>A225</TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
-        \   <PublicMessage>A225\\n17:20 - Cork to Dublin Heuston (-2 mins late)\\nDeparted
-        Portlaoise next stop Dublin Heuston</PublicMessage>\r\n    <Direction>To Dublin
-        Heuston</Direction>\r\n  </objTrainPositions>\r\n  <objTrainPositions>\r\n
-        \   <TrainStatus>R</TrainStatus>\r\n    <TrainLatitude>53.1454</TrainLatitude>\r\n
-        \   <TrainLongitude>-7.06361</TrainLongitude>\r\n    <TrainCode>A716</TrainCode>\r\n
-        \   <TrainDate>19 Apr 2014</TrainDate>\r\n    <PublicMessage>A716\\n18:30
-        - Dublin Heuston to Galway (3 mins late)\\nDeparted Monasterevin next stop
-        Portarlington</PublicMessage>\r\n    <Direction>To Galway</Direction>\r\n
+        \   <TrainLatitude>53.1545</TrainLatitude>\r\n    <TrainLongitude>-6.96542</TrainLongitude>\r\n
+        \   <TrainCode>A516</TrainCode>\r\n    <TrainDate>05 Oct 2015</TrainDate>\r\n
+        \   <PublicMessage>A516\\n20:15 - Dublin Heuston to Carlow (1 mins late)\\nDeparted
+        Cherryville Junction next stop Athy</PublicMessage>\r\n    <Direction>To Carlow</Direction>\r\n
         \ </objTrainPositions>\r\n  <objTrainPositions>\r\n    <TrainStatus>R</TrainStatus>\r\n
         \   <TrainLatitude>53.163</TrainLatitude>\r\n    <TrainLongitude>-6.90802</TrainLongitude>\r\n
-        \   <TrainCode>A514</TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
-        \   <PublicMessage>A514\\n18:35 - Dublin Heuston to Waterford (1 mins late)\\nDeparted
-        Kildare next stop Athy</PublicMessage>\r\n    <Direction>To Waterford</Direction>\r\n
-        \ </objTrainPositions>\r\n  <objTrainPositions>\r\n    <TrainStatus>R</TrainStatus>\r\n
-        \   <TrainLatitude>53.1855</TrainLatitude>\r\n    <TrainLongitude>-6.80807</TrainLongitude>\r\n
-        \   <TrainCode>D215</TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
-        \   <PublicMessage>D215\\n18:25 - Dublin Heuston to Portlaoise (0 mins late)\\nDeparted
-        Newbridge next stop Kildare</PublicMessage>\r\n    <Direction>To Portlaoise</Direction>\r\n
-        \ </objTrainPositions>\r\n  <objTrainPositions>\r\n    <TrainStatus>R</TrainStatus>\r\n
-        \   <TrainLatitude>53.2043</TrainLatitude>\r\n    <TrainLongitude>-6.10046</TrainLongitude>\r\n
-        \   <TrainCode>E124</TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
-        \   <PublicMessage>E124\\n18:00 - Howth to Greystones (-1 mins late)\\nArrived
-        Bray next stop Greystones</PublicMessage>\r\n    <Direction>Southbound</Direction>\r\n
+        \   <TrainCode>A807</TrainCode>\r\n    <TrainDate>05 Oct 2015</TrainDate>\r\n
+        \   <PublicMessage>A807\\n18:15 - Westport to Dublin Heuston (4 mins late)\\nDeparted
+        Kildare next stop Dublin Heuston</PublicMessage>\r\n    <Direction>To Dublin
+        Heuston</Direction>\r\n  </objTrainPositions>\r\n  <objTrainPositions>\r\n
+        \   <TrainStatus>R</TrainStatus>\r\n    <TrainLatitude>53.163</TrainLatitude>\r\n
+        \   <TrainLongitude>-6.90802</TrainLongitude>\r\n    <TrainCode>P221</TrainCode>\r\n
+        \   <TrainDate>05 Oct 2015</TrainDate>\r\n    <PublicMessage>P221\\n20:25
+        - Portlaoise to Dublin Heuston (12 mins late)\\nDeparted Kildare next stop
+        Newbridge</PublicMessage>\r\n    <Direction>To Dublin Heuston</Direction>\r\n
         \ </objTrainPositions>\r\n  <objTrainPositions>\r\n    <TrainStatus>R</TrainStatus>\r\n
         \   <TrainLatitude>53.2135</TrainLatitude>\r\n    <TrainLongitude>-7.35205</TrainLongitude>\r\n
-        \   <TrainCode>A717</TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
-        \   <PublicMessage>A717\\n17:20 - Galway to Dublin Heuston (3 mins late)\\nDeparted
+        \   <TrainCode>A719</TrainCode>\r\n    <TrainDate>05 Oct 2015</TrainDate>\r\n
+        \   <PublicMessage>A719\\n19:20 - Galway to Dublin Heuston (4 mins late)\\nDeparted
         Geashill next stop Portarlington</PublicMessage>\r\n    <Direction>To Dublin
         Heuston</Direction>\r\n  </objTrainPositions>\r\n  <objTrainPositions>\r\n
-        \   <TrainStatus>R</TrainStatus>\r\n    <TrainLatitude>53.2135</TrainLatitude>\r\n
-        \   <TrainLongitude>-7.35205</TrainLongitude>\r\n    <TrainCode>A808</TrainCode>\r\n
-        \   <TrainDate>19 Apr 2014</TrainDate>\r\n    <PublicMessage>A808\\n18:15
-        - Dublin Heuston to Westport (6 mins late)\\nDeparted Geashill next stop Tullamore</PublicMessage>\r\n
-        \   <Direction>To Westport</Direction>\r\n  </objTrainPositions>\r\n  <objTrainPositions>\r\n
-        \   <TrainStatus>R</TrainStatus>\r\n    <TrainLatitude>53.2364</TrainLatitude>\r\n
-        \   <TrainLongitude>-6.11691</TrainLongitude>\r\n    <TrainCode>A612</TrainCode>\r\n
-        \   <TrainDate>19 Apr 2014</TrainDate>\r\n    <PublicMessage>A612\\n18:38
-        - Dublin Connolly to Rosslare Europort (-4 mins late)\\nDeparted Shankill
-        next stop Bray</PublicMessage>\r\n    <Direction>Southbound</Direction>\r\n
-        \ </objTrainPositions>\r\n  <objTrainPositions>\r\n    <TrainStatus>R</TrainStatus>\r\n
-        \   <TrainLatitude>53.2469</TrainLatitude>\r\n    <TrainLongitude>-6.66386</TrainLongitude>\r\n
-        \   <TrainCode>P218</TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
-        \   <PublicMessage>P218\\n18:25 - Portlaoise to Dublin Heuston (0 mins late)\\nDeparted
-        Sallins next stop Hazelhatch</PublicMessage>\r\n    <Direction>To Dublin Heuston</Direction>\r\n
-        \ </objTrainPositions>\r\n  <objTrainPositions>\r\n    <TrainStatus>R</TrainStatus>\r\n
-        \   <TrainLatitude>53.2736</TrainLatitude>\r\n    <TrainLongitude>-9.04696</TrainLongitude>\r\n
-        \   <TrainCode>A719</TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
-        \   <PublicMessage>A719\\n19:20 - Galway to Dublin Heuston (0 mins late)\\nDeparted
-        Galway next stop Athenry</PublicMessage>\r\n    <Direction>To Dublin Heuston</Direction>\r\n
-        \ </objTrainPositions>\r\n  <objTrainPositions>\r\n    <TrainStatus>R</TrainStatus>\r\n
-        \   <TrainLatitude>53.2736</TrainLatitude>\r\n    <TrainLongitude>-9.04696</TrainLongitude>\r\n
-        \   <TrainCode>A721</TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
-        \   <PublicMessage>A721\\n18:10 - Galway to Athlone (0 mins late)\\nDeparted
-        Galway next stop Oranmore</PublicMessage>\r\n    <Direction>To Athlone</Direction>\r\n
-        \ </objTrainPositions>\r\n  <objTrainPositions>\r\n    <TrainStatus>R</TrainStatus>\r\n
-        \   <TrainLatitude>53.2812</TrainLatitude>\r\n    <TrainLongitude>-6.12289</TrainLongitude>\r\n
-        \   <TrainCode>E827</TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
-        \   <PublicMessage>E827\\n18:55 - Bray to Malahide (1 mins late)\\nArrived
-        Glenageary next stop Sandycove</PublicMessage>\r\n    <Direction>Northbound</Direction>\r\n
-        \ </objTrainPositions>\r\n  <objTrainPositions>\r\n    <TrainStatus>R</TrainStatus>\r\n
-        \   <TrainLatitude>53.2951</TrainLatitude>\r\n    <TrainLongitude>-6.13498</TrainLongitude>\r\n
-        \   <TrainCode>E225</TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
-        \   <PublicMessage>E225\\n18:17 - Malahide to Bray (4 mins late)\\nDeparted
-        Dun Laoghaire next stop Sandycove</PublicMessage>\r\n    <Direction>Southbound</Direction>\r\n
-        \ </objTrainPositions>\r\n  <objTrainPositions>\r\n    <TrainStatus>R</TrainStatus>\r\n
-        \   <TrainLatitude>53.3099</TrainLatitude>\r\n    <TrainLongitude>-6.19498</TrainLongitude>\r\n
-        \   <TrainCode>E251</TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
-        \   <PublicMessage>E251\\n18:30 - Howth to Bray (0 mins late)\\nArrived Booterstown
-        next stop Blackrock</PublicMessage>\r\n    <Direction>Southbound</Direction>\r\n
-        \ </objTrainPositions>\r\n  <objTrainPositions>\r\n    <TrainStatus>R</TrainStatus>\r\n
-        \   <TrainLatitude>53.3099</TrainLatitude>\r\n    <TrainLongitude>-6.19498</TrainLongitude>\r\n
-        \   <TrainCode>E930</TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
-        \   <PublicMessage>E930\\n18:30 - Greystones to Howth (0 mins late)\\nArrived
-        Booterstown next stop Sydney Parade</PublicMessage>\r\n    <Direction>Northbound</Direction>\r\n
+        \   <TrainStatus>R</TrainStatus>\r\n    <TrainLatitude>53.2557</TrainLatitude>\r\n
+        \   <TrainLongitude>-6.11317</TrainLongitude>\r\n    <TrainCode>E935</TrainCode>\r\n
+        \   <TrainDate>05 Oct 2015</TrainDate>\r\n    <PublicMessage>E935\\n20:55
+        - Bray to Howth (0 mins late)\\nDeparted Killiney next stop Dalkey</PublicMessage>\r\n
+        \   <Direction>Northbound</Direction>\r\n  </objTrainPositions>\r\n  <objTrainPositions>\r\n
+        \   <TrainStatus>R</TrainStatus>\r\n    <TrainLatitude>53.2756</TrainLatitude>\r\n
+        \   <TrainLongitude>-6.10333</TrainLongitude>\r\n    <TrainCode>E128</TrainCode>\r\n
+        \   <TrainDate>05 Oct 2015</TrainDate>\r\n    <PublicMessage>E128\\n20:00
+        - Howth to Greystones (8 mins late)\\nArrived Dalkey next stop Killiney</PublicMessage>\r\n
+        \   <Direction>Southbound</Direction>\r\n  </objTrainPositions>\r\n  <objTrainPositions>\r\n
+        \   <TrainStatus>R</TrainStatus>\r\n    <TrainLatitude>53.2951</TrainLatitude>\r\n
+        \   <TrainLongitude>-6.13498</TrainLongitude>\r\n    <TrainCode>E229</TrainCode>\r\n
+        \   <TrainDate>05 Oct 2015</TrainDate>\r\n    <PublicMessage>E229\\n20:15
+        - Malahide to Bray (1 mins late)\\nDeparted Dun Laoghaire next stop Sandycove</PublicMessage>\r\n
+        \   <Direction>Southbound</Direction>\r\n  </objTrainPositions>\r\n  <objTrainPositions>\r\n
+        \   <TrainStatus>R</TrainStatus>\r\n    <TrainLatitude>53.3027</TrainLatitude>\r\n
+        \   <TrainLongitude>-6.17833</TrainLongitude>\r\n    <TrainCode>E830</TrainCode>\r\n
+        \   <TrainDate>05 Oct 2015</TrainDate>\r\n    <PublicMessage>E830\\n20:30
+        - Greystones to Malahide (0 mins late)\\nArrived Blackrock next stop Booterstown</PublicMessage>\r\n
+        \   <Direction>Northbound</Direction>\r\n  </objTrainPositions>\r\n  <objTrainPositions>\r\n
+        \   <TrainStatus>R</TrainStatus>\r\n    <TrainLatitude>53.334</TrainLatitude>\r\n
+        \   <TrainLongitude>-6.37868</TrainLongitude>\r\n    <TrainCode>A227</TrainCode>\r\n
+        \   <TrainDate>05 Oct 2015</TrainDate>\r\n    <PublicMessage>A227\\n18:20
+        - Cork to Dublin Heuston (10 mins late)\\nDeparted Cherry Orchard next stop
+        Dublin Heuston</PublicMessage>\r\n    <Direction>To Dublin Heuston</Direction>\r\n
         \ </objTrainPositions>\r\n  <objTrainPositions>\r\n    <TrainStatus>R</TrainStatus>\r\n
         \   <TrainLatitude>53.334</TrainLatitude>\r\n    <TrainLongitude>-6.37868</TrainLongitude>\r\n
-        \   <TrainCode>A223</TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
-        \   <PublicMessage>A223\\n16:20 - Cork to Dublin Heuston (-2 mins late)\\nDeparted
+        \   <TrainCode>P220</TrainCode>\r\n    <TrainDate>05 Oct 2015</TrainDate>\r\n
+        \   <PublicMessage>P220\\n19:30 - Portlaoise to Dublin Heuston (31 mins late)\\nDeparted
         Cherry Orchard next stop Dublin Heuston</PublicMessage>\r\n    <Direction>To
         Dublin Heuston</Direction>\r\n  </objTrainPositions>\r\n  <objTrainPositions>\r\n
-        \   <TrainStatus>R</TrainStatus>\r\n    <TrainLatitude>53.3353</TrainLatitude>\r\n
-        \   <TrainLongitude>-6.45233</TrainLongitude>\r\n    <TrainCode>A226</TrainCode>\r\n
-        \   <TrainDate>19 Apr 2014</TrainDate>\r\n    <PublicMessage>A226\\n19:00
-        - Dublin Heuston to Cork (0 mins late)\\nDeparted Adamstown next stop Portlaoise</PublicMessage>\r\n
-        \   <Direction>To Cork</Direction>\r\n  </objTrainPositions>\r\n  <objTrainPositions>\r\n
-        \   <TrainStatus>R</TrainStatus>\r\n    <TrainLatitude>53.3531</TrainLatitude>\r\n
-        \   <TrainLongitude>-6.24591</TrainLongitude>\r\n    <TrainCode>E226</TrainCode>\r\n
-        \   <TrainDate>19 Apr 2014</TrainDate>\r\n    <PublicMessage>E226\\n18:45
-        - Howth to Bray (0 mins late)\\nArrived Dublin Connolly next stop Tara Street</PublicMessage>\r\n
+        \   <TrainStatus>R</TrainStatus>\r\n    <TrainLatitude>53.3347</TrainLatitude>\r\n
+        \   <TrainLongitude>-6.22979</TrainLongitude>\r\n    <TrainCode>E129</TrainCode>\r\n
+        \   <TrainDate>05 Oct 2015</TrainDate>\r\n    <PublicMessage>E129\\n20:30
+        - Howth to Greystones (1 mins late)\\nDeparted Lansdowne Road next stop Sandymount</PublicMessage>\r\n
         \   <Direction>Southbound</Direction>\r\n  </objTrainPositions>\r\n  <objTrainPositions>\r\n
-        \   <TrainStatus>R</TrainStatus>\r\n    <TrainLatitude>53.3531</TrainLatitude>\r\n
-        \   <TrainLongitude>-6.24591</TrainLongitude>\r\n    <TrainCode>E826</TrainCode>\r\n
-        \   <TrainDate>19 Apr 2014</TrainDate>\r\n    <PublicMessage>E826\\n18:25
-        - Bray to Malahide (0 mins late)\\nDeparted Dublin Connolly next stop Clontarf
-        Road</PublicMessage>\r\n    <Direction>Northbound</Direction>\r\n  </objTrainPositions>\r\n
-        \ <objTrainPositions>\r\n    <TrainStatus>R</TrainStatus>\r\n    <TrainLatitude>53.3632</TrainLatitude>\r\n
-        \   <TrainLongitude>-6.25908</TrainLongitude>\r\n    <TrainCode>A914</TrainCode>\r\n
-        \   <TrainDate>19 Apr 2014</TrainDate>\r\n    <PublicMessage>A914\\n19:05
-        - Dublin Connolly to Sligo (1 mins late)\\nDeparted Drumcondra next stop Maynooth</PublicMessage>\r\n
+        \   <TrainStatus>R</TrainStatus>\r\n    <TrainLatitude>53.3433</TrainLatitude>\r\n
+        \   <TrainLongitude>-6.24829</TrainLongitude>\r\n    <TrainCode>E934</TrainCode>\r\n
+        \   <TrainDate>05 Oct 2015</TrainDate>\r\n    <PublicMessage>E934\\n20:25
+        - Bray to Howth (2 mins late)\\nDeparted Dublin Pearse next stop Tara Street</PublicMessage>\r\n
         \   <Direction>Northbound</Direction>\r\n  </objTrainPositions>\r\n  <objTrainPositions>\r\n
-        \   <TrainStatus>R</TrainStatus>\r\n    <TrainLatitude>53.3755</TrainLatitude>\r\n
-        \   <TrainLongitude>-6.33135</TrainLongitude>\r\n    <TrainCode>P667</TrainCode>\r\n
-        \   <TrainDate>19 Apr 2014</TrainDate>\r\n    <PublicMessage>P667\\n18:40
-        - Maynooth to Dublin Pearse (3 mins late)\\nDeparted Ashtown next stop Broombridge</PublicMessage>\r\n
-        \   <Direction>Southbound</Direction>\r\n  </objTrainPositions>\r\n  <objTrainPositions>\r\n
-        \   <TrainStatus>R</TrainStatus>\r\n    <TrainLatitude>53.3776</TrainLatitude>\r\n
-        \   <TrainLongitude>-6.39072</TrainLongitude>\r\n    <TrainCode>D927</TrainCode>\r\n
-        \   <TrainDate>19 Apr 2014</TrainDate>\r\n    <PublicMessage>D927\\n18:40
-        - Dublin Pearse to Maynooth (2 mins late)\\nDeparted Coolmine next stop Clonsilla</PublicMessage>\r\n
-        \   <Direction>Northbound</Direction>\r\n  </objTrainPositions>\r\n  <objTrainPositions>\r\n
-        \   <TrainStatus>R</TrainStatus>\r\n    <TrainLatitude>53.378</TrainLatitude>\r\n
-        \   <TrainLongitude>-6.58993</TrainLongitude>\r\n    <TrainCode>A910</TrainCode>\r\n
-        \   <TrainDate>19 Apr 2014</TrainDate>\r\n    <PublicMessage>A910\\n16:00
-        - Dublin Connolly to Sligo (0 mins late)\\nDeparted Maynooth next stop Kilcock</PublicMessage>\r\n
-        \   <Direction>Northbound</Direction>\r\n  </objTrainPositions>\r\n  <objTrainPositions>\r\n
-        \   <TrainStatus>R</TrainStatus>\r\n    <TrainLatitude>53.378</TrainLatitude>\r\n
-        \   <TrainLongitude>-6.58993</TrainLongitude>\r\n    <TrainCode>A912</TrainCode>\r\n
-        \   <TrainDate>19 Apr 2014</TrainDate>\r\n    <PublicMessage>A912\\n17:05
-        - Dublin Connolly to Sligo (3 mins late)\\nDeparted Maynooth next stop Kilcock</PublicMessage>\r\n
-        \   <Direction>Northbound</Direction>\r\n  </objTrainPositions>\r\n  <objTrainPositions>\r\n
-        \   <TrainStatus>R</TrainStatus>\r\n    <TrainLatitude>53.3909</TrainLatitude>\r\n
-        \   <TrainLongitude>-6.15672</TrainLongitude>\r\n    <TrainCode>A134</TrainCode>\r\n
-        \   <TrainDate>19 Apr 2014</TrainDate>\r\n    <PublicMessage>A134\\n19:00
-        - Dublin Connolly to Belfast Central (0 mins late)\\nDeparted Howth Junction
-        next stop Drogheda</PublicMessage>\r\n    <Direction>Northbound</Direction>\r\n
+        \   <TrainStatus>R</TrainStatus>\r\n    <TrainLatitude>53.347</TrainLatitude>\r\n
+        \   <TrainLongitude>-6.25425</TrainLongitude>\r\n    <TrainCode>P623</TrainCode>\r\n
+        \   <TrainDate>05 Oct 2015</TrainDate>\r\n    <PublicMessage>P623\\n20:05
+        - Drogheda to Dublin Pearse (3 mins late)\\nArrived Tara Street next stop
+        Dublin Pearse</PublicMessage>\r\n    <Direction>Southbound</Direction>\r\n
+        \ </objTrainPositions>\r\n  <objTrainPositions>\r\n    <TrainStatus>R</TrainStatus>\r\n
+        \   <TrainLatitude>53.3629</TrainLatitude>\r\n    <TrainLongitude>-6.22753</TrainLongitude>\r\n
+        \   <TrainCode>E829</TrainCode>\r\n    <TrainDate>05 Oct 2015</TrainDate>\r\n
+        \   <PublicMessage>E829\\n20:00 - Greystones to Malahide (5 mins late)\\nDeparted
+        Clontarf Road next stop Killester</PublicMessage>\r\n    <Direction>Northbound</Direction>\r\n
+        \ </objTrainPositions>\r\n  <objTrainPositions>\r\n    <TrainStatus>R</TrainStatus>\r\n
+        \   <TrainLatitude>53.3632</TrainLatitude>\r\n    <TrainLongitude>-6.25908</TrainLongitude>\r\n
+        \   <TrainCode>A913</TrainCode>\r\n    <TrainDate>05 Oct 2015</TrainDate>\r\n
+        \   <PublicMessage>A913\\n18:00 - Sligo to Dublin Connolly (3 mins late)\\nArrived
+        Drumcondra next stop Dublin Connolly</PublicMessage>\r\n    <Direction>Southbound</Direction>\r\n
+        \ </objTrainPositions>\r\n  <objTrainPositions>\r\n    <TrainStatus>R</TrainStatus>\r\n
+        \   <TrainLatitude>53.373</TrainLatitude>\r\n    <TrainLongitude>-6.20442</TrainLongitude>\r\n
+        \   <TrainCode>E230</TrainCode>\r\n    <TrainDate>05 Oct 2015</TrainDate>\r\n
+        \   <PublicMessage>E230\\n20:45 - Howth to Bray (2 mins late)\\nDeparted Killester
+        next stop Clontarf Road</PublicMessage>\r\n    <Direction>Southbound</Direction>\r\n
+        \ </objTrainPositions>\r\n  <objTrainPositions>\r\n    <TrainStatus>R</TrainStatus>\r\n
+        \   <TrainLatitude>53.378</TrainLatitude>\r\n    <TrainLongitude>-6.58993</TrainLongitude>\r\n
+        \   <TrainCode>A914</TrainCode>\r\n    <TrainDate>05 Oct 2015</TrainDate>\r\n
+        \   <PublicMessage>A914\\n19:05 - Dublin Connolly to Sligo (0 mins late)\\nDeparted
+        Maynooth next stop Kilcock</PublicMessage>\r\n    <Direction>Northbound</Direction>\r\n
+        \ </objTrainPositions>\r\n  <objTrainPositions>\r\n    <TrainStatus>R</TrainStatus>\r\n
+        \   <TrainLatitude>53.3831</TrainLatitude>\r\n    <TrainLongitude>-6.4242</TrainLongitude>\r\n
+        \   <TrainCode>P670</TrainCode>\r\n    <TrainDate>05 Oct 2015</TrainDate>\r\n
+        \   <PublicMessage>P670\\n20:47 - Maynooth to Dublin Pearse (4 mins late)\\nArrived
+        Clonsilla next stop Coolmine</PublicMessage>\r\n    <Direction>Southbound</Direction>\r\n
         \ </objTrainPositions>\r\n  <objTrainPositions>\r\n    <TrainStatus>R</TrainStatus>\r\n
         \   <TrainLatitude>53.3909</TrainLatitude>\r\n    <TrainLongitude>-6.15672</TrainLongitude>\r\n
-        \   <TrainCode>E126</TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
-        \   <PublicMessage>E126\\n19:00 - Howth to Greystones (0 mins late)\\nDeparted
-        Howth Junction next stop Kilbarrack</PublicMessage>\r\n    <Direction>Southbound</Direction>\r\n
+        \   <TrainCode>A136</TrainCode>\r\n    <TrainDate>05 Oct 2015</TrainDate>\r\n
+        \   <PublicMessage>A136\\n20:50 - Dublin Connolly to Belfast Central (7 mins
+        late)\\nDeparted Howth Junction next stop Drogheda</PublicMessage>\r\n    <Direction>Northbound</Direction>\r\n
         \ </objTrainPositions>\r\n  <objTrainPositions>\r\n    <TrainStatus>R</TrainStatus>\r\n
         \   <TrainLatitude>53.3909</TrainLatitude>\r\n    <TrainLongitude>-6.15672</TrainLongitude>\r\n
-        \   <TrainCode>E928</TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
-        \   <PublicMessage>E928\\n18:10 - Bray to Howth (1 mins late)\\nDeparted Howth
-        Junction next stop Bayside</PublicMessage>\r\n    <Direction>Northbound</Direction>\r\n
+        \   <TrainCode>D825</TrainCode>\r\n    <TrainDate>05 Oct 2015</TrainDate>\r\n
+        \   <PublicMessage>D825\\n20:44 - Dublin Pearse to Drogheda (0 mins late)\\nDeparted
+        Howth Junction next stop Portmarnock</PublicMessage>\r\n    <Direction>Northbound</Direction>\r\n
         \ </objTrainPositions>\r\n  <objTrainPositions>\r\n    <TrainStatus>R</TrainStatus>\r\n
-        \   <TrainLatitude>53.5741</TrainLatitude>\r\n    <TrainLongitude>-6.11933</TrainLongitude>\r\n
-        \   <TrainCode>D818</TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
-        \   <PublicMessage>D818\\n18:40 - Dublin Connolly to Drogheda (1 mins late)\\nDeparted
-        Skerries next stop Balbriggan</PublicMessage>\r\n    <Direction>Northbound</Direction>\r\n
+        \   <TrainLatitude>53.4169</TrainLatitude>\r\n    <TrainLongitude>-6.1512</TrainLongitude>\r\n
+        \   <TrainCode>E130</TrainCode>\r\n    <TrainDate>05 Oct 2015</TrainDate>\r\n
+        \   <PublicMessage>E130\\n21:00 - Malahide to Greystones (1 mins late)\\nDeparted
+        Portmarnock next stop Clongriffin</PublicMessage>\r\n    <Direction>Southbound</Direction>\r\n
         \ </objTrainPositions>\r\n  <objTrainPositions>\r\n    <TrainStatus>R</TrainStatus>\r\n
-        \   <TrainLatitude>53.6118</TrainLatitude>\r\n    <TrainLongitude>-6.18226</TrainLongitude>\r\n
-        \   <TrainCode>P622</TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
-        \   <PublicMessage>P622\\n18:50 - Drogheda to Dublin Pearse (1 mins late)\\nDeparted
-        Balbriggan next stop Skerries</PublicMessage>\r\n    <Direction>Southbound</Direction>\r\n
+        \   <TrainLatitude>53.4175</TrainLatitude>\r\n    <TrainLongitude>-6.46483</TrainLongitude>\r\n
+        \   <TrainCode>P326</TrainCode>\r\n    <TrainDate>05 Oct 2015</TrainDate>\r\n
+        \   <PublicMessage>P326\\n21:00 - M3 Parkway to Clonsilla (1 mins late)\\nDeparted
+        Dunboyne next stop Hansfield</PublicMessage>\r\n    <Direction>Southbound</Direction>\r\n
         \ </objTrainPositions>\r\n  <objTrainPositions>\r\n    <TrainStatus>R</TrainStatus>\r\n
-        \   <TrainLatitude>53.6635</TrainLatitude>\r\n    <TrainLongitude>-6.23271</TrainLongitude>\r\n
-        \   <TrainCode>D817</TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
-        \   <PublicMessage>D817\\n18:16 - Dublin Pearse to Drogheda (0 mins late)\\nDeparted
-        Mosney next stop Laytown</PublicMessage>\r\n    <Direction>Northbound</Direction>\r\n
+        \   <TrainLatitude>53.4273</TrainLatitude>\r\n    <TrainLongitude>-7.93683</TrainLongitude>\r\n
+        \   <TrainCode>A718</TrainCode>\r\n    <TrainDate>05 Oct 2015</TrainDate>\r\n
+        \   <PublicMessage>A718\\n19:35 - Dublin Heuston to Galway (2 mins late)\\nDeparted
+        Athlone next stop Ballinasloe</PublicMessage>\r\n    <Direction>To Galway</Direction>\r\n
         \ </objTrainPositions>\r\n  <objTrainPositions>\r\n    <TrainStatus>R</TrainStatus>\r\n
-        \   <TrainLatitude>53.712</TrainLatitude>\r\n    <TrainLongitude>-6.33538</TrainLongitude>\r\n
-        \   <TrainCode>A132</TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
-        \   <PublicMessage>A132\\n16:50 - Dublin Connolly to Belfast Central (0 mins
-        late)\\nArrived Drogheda next stop Dundalk</PublicMessage>\r\n    <Direction>Northbound</Direction>\r\n
+        \   <TrainLatitude>53.638</TrainLatitude>\r\n    <TrainLongitude>-6.21705</TrainLongitude>\r\n
+        \   <TrainCode>D820</TrainCode>\r\n    <TrainDate>05 Oct 2015</TrainDate>\r\n
+        \   <PublicMessage>D820\\n20:13 - Dublin Pearse to Drogheda (2 mins late)\\nArrived
+        Gormanston next stop Laytown</PublicMessage>\r\n    <Direction>Northbound</Direction>\r\n
         \ </objTrainPositions>\r\n  <objTrainPositions>\r\n    <TrainStatus>R</TrainStatus>\r\n
-        \   <TrainLatitude>53.7955</TrainLatitude>\r\n    <TrainLongitude>-9.50885</TrainLongitude>\r\n
-        \   <TrainCode>A807</TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
-        \   <PublicMessage>A807\\n18:15 - Westport to Dublin Heuston (0 mins late)\\nDeparted
-        Westport next stop Castlebar</PublicMessage>\r\n    <Direction>To Dublin Heuston</Direction>\r\n
+        \   <TrainLatitude>54.0007</TrainLatitude>\r\n    <TrainLongitude>-6.41291</TrainLongitude>\r\n
+        \   <TrainCode>A134</TrainCode>\r\n    <TrainDate>05 Oct 2015</TrainDate>\r\n
+        \   <PublicMessage>A134\\n19:00 - Dublin Connolly to Belfast Central (2 mins
+        late)\\nDeparted Dundalk next stop Newry</PublicMessage>\r\n    <Direction>Northbound</Direction>\r\n
         \ </objTrainPositions>\r\n  <objTrainPositions>\r\n    <TrainStatus>T</TrainStatus>\r\n
-        \   <TrainLatitude>52.1396</TrainLatitude>\r\n    <TrainLongitude>-8.65521</TrainLongitude>\r\n
-        \   <TrainCode>P252</TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
-        \   <PublicMessage>P252\\n18:45 - Cork to Mallow(-3 mins late)\\nTERMINATED
-        Mallow at 19:07</PublicMessage>\r\n    <Direction>To Mallow</Direction>\r\n
-        \ </objTrainPositions>\r\n  <objTrainPositions>\r\n    <TrainStatus>T</TrainStatus>\r\n
-        \   <TrainLatitude>53.3433</TrainLatitude>\r\n    <TrainLongitude>-6.24829</TrainLongitude>\r\n
-        \   <TrainCode>P620</TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
-        \   <PublicMessage>P620\\n18:00 - Drogheda to Dublin Pearse(3 mins late)\\nTERMINATED
-        Dublin Pearse at 19:06</PublicMessage>\r\n    <Direction>Southbound</Direction>\r\n
-        \ </objTrainPositions>\r\n  <objTrainPositions>\r\n    <TrainStatus>T</TrainStatus>\r\n
-        \   <TrainLatitude>53.4509</TrainLatitude>\r\n    <TrainLongitude>-6.15649</TrainLongitude>\r\n
-        \   <TrainCode>E825</TrainCode>\r\n    <TrainDate>19 Apr 2014</TrainDate>\r\n
-        \   <PublicMessage>E825\\n17:55 - Bray to Malahide(-2 mins late)\\nTERMINATED
-        Malahide at 19:03</PublicMessage>\r\n    <Direction>Northbound</Direction>\r\n
+        \   <TrainLatitude>53.3891</TrainLatitude>\r\n    <TrainLongitude>-6.07401</TrainLongitude>\r\n
+        \   <TrainCode>E933</TrainCode>\r\n    <TrainDate>05 Oct 2015</TrainDate>\r\n
+        \   <PublicMessage>E933\\n19:55 - Bray to Howth(3 mins late)\\nTERMINATED
+        Howth at 21:05</PublicMessage>\r\n    <Direction>Northbound</Direction>\r\n
         \ </objTrainPositions>\r\n</ArrayOfObjTrainPositions>"
     http_version: 
-  recorded_at: Sat, 19 Apr 2014 18:10:58 GMT
-recorded_with: VCR 2.9.0
+  recorded_at: Mon, 05 Oct 2015 20:06:38 GMT
+recorded_with: VCR 2.9.3

--- a/fixtures/vcr_cassettes/westbound.yml
+++ b/fixtures/vcr_cassettes/westbound.yml
@@ -25,64 +25,76 @@ http_interactions:
       Server:
       - ''
       Date:
-      - Sat, 19 Apr 2014 18:10:55 GMT
+      - Mon, 05 Oct 2015 20:06:37 GMT
       Content-Length:
-      - '4266'
+      - '5152'
     body:
       encoding: UTF-8
       string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<ArrayOfObjStationData
         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-        xmlns=\"http://api.irishrail.ie/realtime/\">\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.677</Servertime>\r\n
-        \   <Traincode>E826 </Traincode>\r\n    <Stationfullname>Clongriffin</Stationfullname>\r\n
-        \   <Stationcode>GRGRD</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Bray</Origin>\r\n    <Destination>Malahide</Destination>\r\n
-        \   <Origintime>18:25</Origintime>\r\n    <Destinationtime>19:32</Destinationtime>\r\n
-        \   <Status>En Route</Status>\r\n    <Lastlocation>Departed Dublin Connolly</Lastlocation>\r\n
-        \   <Duein>16</Duein>\r\n    <Late>1</Late>\r\n    <Exparrival>19:25</Exparrival>\r\n
-        \   <Expdepart>19:26</Expdepart>\r\n    <Scharrival>19:25</Scharrival>\r\n
-        \   <Schdepart>19:25</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
+        xmlns=\"http://api.irishrail.ie/realtime/\">\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.783</Servertime>\r\n
+        \   <Traincode>E829 </Traincode>\r\n    <Stationfullname>Clongriffin</Stationfullname>\r\n
+        \   <Stationcode>GRGRD</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Greystones</Origin>\r\n
+        \   <Destination>Malahide</Destination>\r\n    <Origintime>20:00</Origintime>\r\n
+        \   <Destinationtime>21:20</Destinationtime>\r\n    <Status>En Route</Status>\r\n
+        \   <Lastlocation>Departed Clontarf Road</Lastlocation>\r\n    <Duein>12</Duein>\r\n
+        \   <Late>6</Late>\r\n    <Exparrival>21:17</Exparrival>\r\n    <Expdepart>21:18</Expdepart>\r\n
+        \   <Scharrival>21:12</Scharrival>\r\n    <Schdepart>21:12</Schdepart>\r\n
+        \   <Direction>Northbound</Direction>\r\n    <Traintype>DART</Traintype>\r\n
+        \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
+        \   <Servertime>2015-10-05T21:06:38.783</Servertime>\r\n    <Traincode>E830
+        </Traincode>\r\n    <Stationfullname>Clongriffin</Stationfullname>\r\n    <Stationcode>GRGRD</Stationcode>\r\n
+        \   <Querytime>21:06:38</Querytime>\r\n    <Traindate>05 Oct 2015</Traindate>\r\n
+        \   <Origin>Greystones</Origin>\r\n    <Destination>Malahide</Destination>\r\n
+        \   <Origintime>20:30</Origintime>\r\n    <Destinationtime>21:50</Destinationtime>\r\n
+        \   <Status>En Route</Status>\r\n    <Lastlocation>Arrived Blackrock</Lastlocation>\r\n
+        \   <Duein>36</Duein>\r\n    <Late>1</Late>\r\n    <Exparrival>21:41</Exparrival>\r\n
+        \   <Expdepart>21:42</Expdepart>\r\n    <Scharrival>21:41</Scharrival>\r\n
+        \   <Schdepart>21:41</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
         \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.677</Servertime>\r\n
-        \   <Traincode>E827 </Traincode>\r\n    <Stationfullname>Clongriffin</Stationfullname>\r\n
-        \   <Stationcode>GRGRD</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Bray</Origin>\r\n    <Destination>Malahide</Destination>\r\n
-        \   <Origintime>18:55</Origintime>\r\n    <Destinationtime>20:05</Destinationtime>\r\n
-        \   <Status>En Route</Status>\r\n    <Lastlocation>Arrived Glenageary</Lastlocation>\r\n
-        \   <Duein>47</Duein>\r\n    <Late>1</Late>\r\n    <Exparrival>19:57</Exparrival>\r\n
-        \   <Expdepart>19:57</Expdepart>\r\n    <Scharrival>19:56</Scharrival>\r\n
-        \   <Schdepart>19:56</Schdepart>\r\n    <Direction>Northbound</Direction>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.783</Servertime>\r\n
+        \   <Traincode>E831 </Traincode>\r\n    <Stationfullname>Clongriffin</Stationfullname>\r\n
+        \   <Stationcode>GRGRD</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Greystones</Origin>\r\n
+        \   <Destination>Malahide</Destination>\r\n    <Origintime>21:00</Origintime>\r\n
+        \   <Destinationtime>22:20</Destinationtime>\r\n    <Status>En Route</Status>\r\n
+        \   <Lastlocation>Departed Greystones</Lastlocation>\r\n    <Duein>66</Duein>\r\n
+        \   <Late>1</Late>\r\n    <Exparrival>22:11</Exparrival>\r\n    <Expdepart>22:12</Expdepart>\r\n
+        \   <Scharrival>22:11</Scharrival>\r\n    <Schdepart>22:11</Schdepart>\r\n
+        \   <Direction>Northbound</Direction>\r\n    <Traintype>DART</Traintype>\r\n
+        \   <Locationtype>S</Locationtype>\r\n  </objStationData>\r\n  <objStationData>\r\n
+        \   <Servertime>2015-10-05T21:06:38.783</Servertime>\r\n    <Traincode>E130
+        </Traincode>\r\n    <Stationfullname>Clongriffin</Stationfullname>\r\n    <Stationcode>GRGRD</Stationcode>\r\n
+        \   <Querytime>21:06:38</Querytime>\r\n    <Traindate>05 Oct 2015</Traindate>\r\n
+        \   <Origin>Malahide</Origin>\r\n    <Destination>Greystones</Destination>\r\n
+        \   <Origintime>21:00</Origintime>\r\n    <Destinationtime>22:20</Destinationtime>\r\n
+        \   <Status>En Route</Status>\r\n    <Lastlocation>Departed Portmarnock</Lastlocation>\r\n
+        \   <Duein>2</Duein>\r\n    <Late>1</Late>\r\n    <Exparrival>21:08</Exparrival>\r\n
+        \   <Expdepart>21:08</Expdepart>\r\n    <Scharrival>21:06</Scharrival>\r\n
+        \   <Schdepart>21:07</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
         \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.677</Servertime>\r\n
-        \   <Traincode>E227 </Traincode>\r\n    <Stationfullname>Clongriffin</Stationfullname>\r\n
-        \   <Stationcode>GRGRD</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Malahide</Origin>\r\n
-        \   <Destination>Bray</Destination>\r\n    <Origintime>19:15</Origintime>\r\n
-        \   <Destinationtime>20:24</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>12</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>19:21</Exparrival>\r\n
-        \   <Expdepart>19:22</Expdepart>\r\n    <Scharrival>19:21</Scharrival>\r\n
-        \   <Schdepart>19:22</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.783</Servertime>\r\n
+        \   <Traincode>E131 </Traincode>\r\n    <Stationfullname>Clongriffin</Stationfullname>\r\n
+        \   <Stationcode>GRGRD</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Malahide</Origin>\r\n
+        \   <Destination>Greystones</Destination>\r\n    <Origintime>21:30</Origintime>\r\n
+        \   <Destinationtime>22:50</Destinationtime>\r\n    <Status>No Information</Status>\r\n
+        \   <Lastlocation />\r\n    <Duein>31</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>21:36</Exparrival>\r\n
+        \   <Expdepart>21:37</Expdepart>\r\n    <Scharrival>21:36</Scharrival>\r\n
+        \   <Schdepart>21:37</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
         \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.677</Servertime>\r\n
-        \   <Traincode>E228 </Traincode>\r\n    <Stationfullname>Clongriffin</Stationfullname>\r\n
-        \   <Stationcode>GRGRD</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Malahide</Origin>\r\n
-        \   <Destination>Bray</Destination>\r\n    <Origintime>19:45</Origintime>\r\n
-        \   <Destinationtime>20:54</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>42</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>19:51</Exparrival>\r\n
-        \   <Expdepart>19:52</Expdepart>\r\n    <Scharrival>19:51</Scharrival>\r\n
-        \   <Schdepart>19:52</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
-        \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
-        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2014-04-19T19:10:55.677</Servertime>\r\n
-        \   <Traincode>E229 </Traincode>\r\n    <Stationfullname>Clongriffin</Stationfullname>\r\n
-        \   <Stationcode>GRGRD</Stationcode>\r\n    <Querytime>19:10:55</Querytime>\r\n
-        \   <Traindate>19 Apr 2014</Traindate>\r\n    <Origin>Malahide</Origin>\r\n
-        \   <Destination>Bray</Destination>\r\n    <Origintime>20:15</Origintime>\r\n
-        \   <Destinationtime>21:24</Destinationtime>\r\n    <Status>No Information</Status>\r\n
-        \   <Lastlocation />\r\n    <Duein>72</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>20:21</Exparrival>\r\n
-        \   <Expdepart>20:22</Expdepart>\r\n    <Scharrival>20:21</Scharrival>\r\n
-        \   <Schdepart>20:22</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
+        \ </objStationData>\r\n  <objStationData>\r\n    <Servertime>2015-10-05T21:06:38.783</Servertime>\r\n
+        \   <Traincode>E710 </Traincode>\r\n    <Stationfullname>Clongriffin</Stationfullname>\r\n
+        \   <Stationcode>GRGRD</Stationcode>\r\n    <Querytime>21:06:38</Querytime>\r\n
+        \   <Traindate>05 Oct 2015</Traindate>\r\n    <Origin>Malahide</Origin>\r\n
+        \   <Destination>Dublin Connolly</Destination>\r\n    <Origintime>22:10</Origintime>\r\n
+        \   <Destinationtime>22:35</Destinationtime>\r\n    <Status>No Information</Status>\r\n
+        \   <Lastlocation />\r\n    <Duein>71</Duein>\r\n    <Late>0</Late>\r\n    <Exparrival>22:16</Exparrival>\r\n
+        \   <Expdepart>22:17</Expdepart>\r\n    <Scharrival>22:16</Scharrival>\r\n
+        \   <Schdepart>22:17</Schdepart>\r\n    <Direction>Southbound</Direction>\r\n
         \   <Traintype>DART</Traintype>\r\n    <Locationtype>S</Locationtype>\r\n
         \ </objStationData>\r\n</ArrayOfObjStationData>"
     http_version: 
-  recorded_at: Sat, 19 Apr 2014 18:10:57 GMT
-recorded_with: VCR 2.9.0
+  recorded_at: Mon, 05 Oct 2015 20:06:37 GMT
+recorded_with: VCR 2.9.3

--- a/ierail.gemspec
+++ b/ierail.gemspec
@@ -10,11 +10,11 @@ Gem::Specification.new do |s|
   s.email       = 'oi.sin@nis.io'
   s.files       = `git ls-files`.split("\n")
   s.homepage    = 'http://rubygems.org/gems/ierail'
-  s.add_runtime_dependency 'json', '~> 1.8', '>= 1.8.1'
+  s.add_runtime_dependency 'json', '~> 1.8', '>= 1.8.3'
   s.add_runtime_dependency 'rest-client', '~> 1.7', '>= 1.7.2'
   s.add_runtime_dependency 'nokogiri', '~> 1.6', '>= 1.6.3'
   s.add_runtime_dependency 'tzinfo', '~> 1.2', '>= 1.2.2'
-  s.add_development_dependency 'vcr', '~> 2.9', '>= 2.9.0'
-  s.add_development_dependency 'webmock', '~> 1.17', '>= 1.17.4'
-  s.add_development_dependency 'timecop', '~> 0.6', '>= 0.6.2'
+  s.add_development_dependency 'vcr', '~> 2.9', '>= 2.9.3'
+  s.add_development_dependency 'webmock', '~> 1.21', '>= 1.21.0'
+  s.add_development_dependency 'timecop', '~> 0.8', '>= 0.8.0'
 end

--- a/lib/station_data.rb
+++ b/lib/station_data.rb
@@ -33,8 +33,16 @@ class StationData
     is_departure_station        = @station_name.eql?(@origin)
     is_terminating_station      = @station_name.eql?(@destination)
 
+    one_day = 86400
+
     @expected_arrival           = is_departure_station ? @origin_time : Time.parse(hash['Exparrival'])
     @expected_departure         = is_terminating_station ? @destination_time : Time.parse(hash['Expdepart'])
+
+    # The API returns expected arr/dep times as HH:MM, if this time has crossed midnight, we parse it as being
+    # earlier 'today'; this then throws off the before/after filters. Use the server time as a sanity check.
+    @expected_arrival = @expected_arrival + one_day if @expected_arrival < @server_time
+    @expected_departure = @expected_departure + one_day if @expected_departure < @server_time
+
     @scheduled_arrival          = is_departure_station ? @origin_time + off_schedule_minutes : Time.parse(hash['Scharrival'])
     @scheduled_departure        = is_terminating_station ? @destination_time + off_schedule_minutes : Time.parse(hash['Schdepart'])
     @direction                  = hash['Direction']

--- a/test/unit/helper.rb
+++ b/test/unit/helper.rb
@@ -8,6 +8,7 @@ require 'minitest/autorun'
 require 'ierail'
 
 def get_original_time(t)
+  t = Time.now if t.nil?
   @when = Time.parse(t.to_s)
   if TZInfo::Timezone.get('Europe/Dublin').current_period.dst?
     unless @when.zone == 'IST'

--- a/test/unit/ierail.rb
+++ b/test/unit/ierail.rb
@@ -51,7 +51,7 @@ class IERailTest < MiniTest::Unit::TestCase
         thirty_mins = Time.now + (60 * 30)
         time = "#{thirty_mins.hour}:#{thirty_mins.min}" # "HH:MM"
         before_train = @ir.southbound_from('Dublin Connolly').before(time).sample
-        assert before_train.expected_departure <= thirty_mins
+        assert before_train.expected_arrival <= thirty_mins
       end
     end
   end
@@ -65,7 +65,7 @@ class IERailTest < MiniTest::Unit::TestCase
         thirty_mins = Time.now + (60 * 30)
         time = "#{thirty_mins.hour}:#{thirty_mins.min}" # "HH:MM"
         after_train = @ir.southbound_from('Dublin Connolly').after(time).sample
-        assert after_train.expected_departure >= thirty_mins
+        assert after_train.expected_arrival >= thirty_mins
       end
     end
   end
@@ -79,7 +79,6 @@ class IERailTest < MiniTest::Unit::TestCase
         thirty_mins = Time.now + (60 * mins)
         time = "#{thirty_mins.hour}:#{thirty_mins.min}" # "HH:MM"
         southbounds = @ir.southbound_from('Dublin Connolly')
-
         before_train = southbounds.before(time)
 
         in_half_an_hour = southbounds.in(mins)


### PR DESCRIPTION
* The IERail server returns expected arrival/departure times as HH:MM. This is problematic if we receive an expected time less than the current time, as it is then parsed as being earlier today, when it should be parsed as tomorrow. This then has a knock on effect on the filters.
* Test-cases were based on the wrong expected time, the filters were all defined based on expected arrival, yet tested on expected departure, causing failures.
* All test cases now appear to pass.